### PR TITLE
p5js/ecosystem - Fix bug in fetching params

### DIFF
--- a/p5js/ecosystem/app.js
+++ b/p5js/ecosystem/app.js
@@ -8,16 +8,16 @@ function setup() {
   noiseSeed(seed);
 
   options = {
-    cellWidth: UtilFunctions.getParameterByName("cellWidth", "", parseInt)
-    , scale: UtilFunctions.getParameterByName("scale", "", Number)
-    , percentWater: UtilFunctions.getParameterByName("percentWater", "", Number)
-    , erosionRate: UtilFunctions.getParameterByName("erosionRate", "", Number)
+    cellWidth: UtilFunctions.getParameterByName("cellWidth", parseInt)
+    , scale: UtilFunctions.getParameterByName("scale", Number)
+    , percentWater: UtilFunctions.getParameterByName("percentWater",Number)
+    , erosionRate: UtilFunctions.getParameterByName("erosionRate", Number)
   };
   UtilFunctions.unsetUndefineds(options);
 
   noiseOptions = {
-    octaves: UtilFunctions.getParameterByName("noise.octaves", "", parseInt) || 10
-    , falloff: UtilFunctions.getParameterByName("noise.falloff", "", Number) || 0.6
+    octaves: UtilFunctions.getParameterByName("noise.octaves", parseInt) || 10
+    , falloff: UtilFunctions.getParameterByName("noise.falloff", Number) || 0.6
   }
   noiseDetail(noiseOptions.octaves, noiseOptions.falloff);
 


### PR DESCRIPTION
Regression caused by parameter order swap on `getParameterByName(...)` in the common version, compared to the deleted local version.