### PR TITLE
P5JS/ecosystem - Refactor rendering of the cells to use single object

### DIFF
--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -10,44 +10,33 @@ class CellGrid {
     this.cellHeight = cellWidth;
     this.cellSpacing = 0;
 
+    this.effectCellWidth = this.cellWidth + this.cellSpacing;
+    this.effectCellHeight = this.cellHeight + this.cellSpacing;
+
     this.initCells();
     this.wrap = false;
   }
 
   initCells() {
     this.cells = [];
-    this.cellViewers = [];
-
-    let effectCellWidth = this.cellWidth + this.cellSpacing;
-    let effectCellHeight = this.cellHeight + this.cellSpacing;
 
     // Note, by using 'ceil' we will overstep the bounds of the width/height;
-    this.numCols = Math.ceil( (1.0 * this._width)  / effectCellWidth );
-    this.numRows = Math.ceil( (1.0 * this._height) / effectCellHeight );
+    this.numCols = Math.ceil( (1.0 * this._width)  / this.effectCellWidth );
+    this.numRows = Math.ceil( (1.0 * this._height) / this.effectCellHeight );
     this.numCells = this.numCols * this.numRows;
 
-    let tmpCell;
-    let tmpCellViewer;
     let tmpRow;
     let tmpCol;
-
-    let tmpX;
-    let tmpY;
+    let tmpCell;
 
     for(let i=0; i<this.numCells; i++){
       tmpCol = i % this.numCols;
       tmpRow = Math.floor(i / this.numCols);
       tmpCell = this.cellProvider.createCell(tmpRow, tmpCol, i);
-
-      tmpX = tmpCol * effectCellWidth;
-      tmpY = tmpRow * effectCellHeight;
-
-      tmpCellViewer = new CellViewer(tmpX, tmpY, this.cellWidth, this.cellHeight, tmpCell);
-
       this.cells.push(tmpCell);
-      this.cellViewers.push(tmpCellViewer);
     }
   }
+
 
   neighborsOfIdx(idx){
     let neighbors = [
@@ -122,10 +111,23 @@ class CellGrid {
     push();
     translate(this._x, this._y);
 
-    let cellViewer;
-    for(let i=0; i<this.cellViewers.length; i++){
-      cellViewer = this.cellViewers[i];
-      cellViewer.renderOnScale(-300, 0, 300);
+    let tmpX;
+    let tmpY;
+    let tmpRow;
+    let tmpCol;
+    let tmpCell;
+
+    let cellViewer = new CellViewer();
+    for(let i=0; i<this.cells.length; i++){
+      tmpCol = i % this.numCols;
+      tmpRow = Math.floor(i / this.numCols);
+      tmpX = tmpCol * this.effectCellWidth;
+      tmpY = tmpRow * this.effectCellHeight;
+
+      tmpCell = this.cells[i];
+      cellViewer.renderCell(tmpCell, tmpX, tmpY, 
+                              this.cellWidth, this.cellHeight, 
+                              -300, 0, 300);
     }
     pop();
   }

--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -126,8 +126,7 @@ class CellGrid {
 
       tmpCell = this.cells[i];
       cellViewer.renderCell(tmpCell, tmpX, tmpY, 
-                              this.cellWidth, this.cellHeight, 
-                              -300, 0, 300);
+                              this.cellWidth, this.cellHeight);
     }
     pop();
   }

--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -113,18 +113,14 @@ class CellGrid {
 
     let tmpX;
     let tmpY;
-    let tmpRow;
-    let tmpCol;
     let tmpCell;
 
     let cellViewer = new CellViewer();
     for(let i=0; i<this.cells.length; i++){
-      tmpCol = i % this.numCols;
-      tmpRow = Math.floor(i / this.numCols);
-      tmpX = tmpCol * this.effectCellWidth;
-      tmpY = tmpRow * this.effectCellHeight;
-
       tmpCell = this.cells[i];
+      tmpX = tmpCell._col * this.effectCellWidth;
+      tmpY = tmpCell._row * this.effectCellHeight;
+
       cellViewer.renderCell(tmpCell, tmpX, tmpY, 
                               this.cellWidth, this.cellHeight);
     }

--- a/p5js/ecosystem/classes/cell_viewer.js
+++ b/p5js/ecosystem/classes/cell_viewer.js
@@ -15,23 +15,18 @@ class CellViewer {
     this.color6 = color(255, 255, 255);
   }
 
-  renderOnScale(minElev, midPoint, maxElev){
-    this.renderCell(this.cell, this._x, this._y, this._width, this._height, 
-                      minElev, midPoint, maxElev);
-  }
-
   renderCell(cell, x, y, p_nWidth, p_nHeight, minElev, midPoint, maxElev){
     let fillColor = color(0);
     let normalizedTmp = 0;
 
-    if (this.cell.elevation < midPoint){
-      normalizedTmp = norm( this.cell.elevation, minElev, midPoint);
+    if (cell.elevation < midPoint){
+      normalizedTmp = norm(cell.elevation, minElev, midPoint);
       fillColor = lerpColor(this.minColor, this.color2, normalizedTmp);
-    }else if(this.cell.elevation < maxElev){
-      normalizedTmp = norm( this.cell.elevation, midPoint, maxElev);
+    }else if(cell.elevation < maxElev){
+      normalizedTmp = norm(cell.elevation, midPoint, maxElev);
       fillColor = lerpColor(this.color4, this.color5, normalizedTmp);
     } else{
-      normalizedTmp = norm( this.cell.elevation, maxElev, 500);
+      normalizedTmp = norm(cell.elevation, maxElev, 500);
       fillColor = lerpColor(this.color5, this.color6, normalizedTmp);
     }
 
@@ -39,7 +34,7 @@ class CellViewer {
     fill(fillColor);
     rect(x, y, p_nWidth, p_nHeight);
 
-    if (this.cell.hasResource()){
+    if (cell.hasResource()){
       fill(255, 0, 0);
       // ellipseMode(CORNERS);
       ellipse(x + p_nWidth / 2, y  + p_nHeight / 2, 2, 2);

--- a/p5js/ecosystem/classes/cell_viewer.js
+++ b/p5js/ecosystem/classes/cell_viewer.js
@@ -13,20 +13,24 @@ class CellViewer {
     this.color4 = color(20,100,40);
     this.color5 = color(180,190,120);
     this.color6 = color(255, 255, 255);
+
+    this._minElev = -300;
+    this._midPoint = 0;
+    this._maxElev = 300;
   }
 
-  renderCell(cell, x, y, p_nWidth, p_nHeight, minElev, midPoint, maxElev){
+  renderCell(cell, x, y, p_nWidth, p_nHeight){
     let fillColor = color(0);
     let normalizedTmp = 0;
 
-    if (cell.elevation < midPoint){
-      normalizedTmp = norm(cell.elevation, minElev, midPoint);
+    if (cell.elevation < this._midPoint){
+      normalizedTmp = norm(cell.elevation, this._minElev, this._midPoint);
       fillColor = lerpColor(this.minColor, this.color2, normalizedTmp);
-    }else if(cell.elevation < maxElev){
-      normalizedTmp = norm(cell.elevation, midPoint, maxElev);
+    }else if(cell.elevation < this._maxElev){
+      normalizedTmp = norm(cell.elevation, this._midPoint, this._maxElev);
       fillColor = lerpColor(this.color4, this.color5, normalizedTmp);
     } else{
-      normalizedTmp = norm(cell.elevation, maxElev, 500);
+      normalizedTmp = norm(cell.elevation, this._maxElev, 500);
       fillColor = lerpColor(this.color5, this.color6, normalizedTmp);
     }
 

--- a/p5js/ecosystem/classes/cell_viewer.js
+++ b/p5js/ecosystem/classes/cell_viewer.js
@@ -16,6 +16,11 @@ class CellViewer {
   }
 
   renderOnScale(minElev, midPoint, maxElev){
+    this.renderCell(this.cell, this._x, this._y, this._width, this._height, 
+                      minElev, midPoint, maxElev);
+  }
+
+  renderCell(cell, x, y, p_nWidth, p_nHeight, minElev, midPoint, maxElev){
     let fillColor = color(0);
     let normalizedTmp = 0;
 
@@ -32,12 +37,13 @@ class CellViewer {
 
     noStroke();
     fill(fillColor);
-    rect(this._x, this._y, this._width, this._height);
+    rect(x, y, p_nWidth, p_nHeight);
 
     if (this.cell.hasResource()){
       fill(255, 0, 0);
       // ellipseMode(CORNERS);
-      ellipse(this._x + this._width / 2, this._y  + this._height / 2, 2, 2);
+      ellipse(x + p_nWidth / 2, y  + p_nHeight / 2, 2, 2);
     }
   }
+
 }


### PR DESCRIPTION
This was driven by the desire to have a single object to render the cells.

Previously, during grid initialization, a `CellViewer` object was created per `Cell`.

Now, when rendering, the `CellGrid` passes each `Cell` to a `CellViewer`.

This PR stops short of fully extracting the concept of the rendering from the `CellGrid`. I'm not quite ready to make that step ... thinking that the current setup benefits from simplicity, rather than having to configure a `CellViewer` or system viewer.

I am interested in multiple views of the same data (for features like minimaps, or visualizing different data in multi-pane interface) but will explore that separately.