### PR TITLE
p5.js/Water Cycle - Derive cell type from rendered terrain

### DIFF
--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -13,6 +13,8 @@ class CellGrid {
     this.effectCellWidth = this.cellWidth + this.cellSpacing;
     this.effectCellHeight = this.cellHeight + this.cellSpacing;
 
+    this.cellViewer = new CellViewer();
+
     this.initCells();
     this.wrap = false;
   }
@@ -115,13 +117,12 @@ class CellGrid {
     let tmpY;
     let tmpCell;
 
-    let cellViewer = new CellViewer();
     for(let i=0; i<this.cells.length; i++){
       tmpCell = this.cells[i];
       tmpX = tmpCell._col * this.effectCellWidth;
       tmpY = tmpCell._row * this.effectCellHeight;
 
-      cellViewer.renderCell(tmpCell, tmpX, tmpY, 
+      this.cellViewer.renderCell(tmpCell, tmpX, tmpY, 
                               this.cellWidth, this.cellHeight);
     }
     pop();

--- a/p5js/common/p5js_utils.js
+++ b/p5js/common/p5js_utils.js
@@ -1,0 +1,17 @@
+class P5JsUtils {
+  static colorAt(x, y, width){
+    let baseIdx = (round(x) + round(y) * width) * 4;
+    return color(
+              pixels[baseIdx + 0], 
+              pixels[baseIdx + 1],
+              pixels[baseIdx + 2],
+              pixels[baseIdx + 3]);
+  }
+
+  static colorsMatch(c1, c2){
+    return      c1.levels[0] == c2.levels[0]
+             && c1.levels[1] == c2.levels[1]
+             && c1.levels[2] == c2.levels[2]
+             && alpha(c1) == alpha(c2);
+  }
+}

--- a/p5js/water-cycle/app.js
+++ b/p5js/water-cycle/app.js
@@ -1,7 +1,5 @@
 let seed;
 let system;
-let terrain;
-let weatherGrid;
 
 function setup() {
   createCanvas(windowWidth, windowHeight-35);
@@ -11,12 +9,9 @@ function setup() {
   frameRate(1);
   system.tick();
 
-  let rect = new Rect(0, 0, width/2, height/2);
-  terrain = new Terrain2D(rect);
-  weatherGrid = new CellGrid(rect, WeatherCell, 20);
 }
 
 function draw(){
   system.tick();
-  terrain.draw();
+  system.draw();
 }

--- a/p5js/water-cycle/app.js
+++ b/p5js/water-cycle/app.js
@@ -1,5 +1,6 @@
 let seed;
 let system;
+let terrain;
 
 function setup() {
   createCanvas(windowWidth, windowHeight-35);
@@ -8,51 +9,12 @@ function setup() {
   system = new System();
   frameRate(1);
   system.tick();
+
+  let rect = new Rect(0, 0, width/2, height/2);
+  terrain = new Terrain2D(rect);
 }
 
 function draw(){
   system.tick();
-  
-  background(170,190,240);
-  drawSlope();
-}
-
-
-function drawSlope(){
-  var noiseScale = 0.01;
-  
-  fill(70,75,10);
-  noStroke();
-  beginShape(); 
-
-  for (var x = 0; x <= width; x += 20) {
-    var y = height - 20;
-
-    y -= (zone1Contribution(x)
-          + zone2Contribution(x) 
-          + zone3Contribution(x) 
-          + zone4Contribution(x));
-    y -= noise(x*noiseScale) * 130;
-
-    vertex(x, y); 
-  }
-  vertex(width, height); // down to bottom-right corner
-  vertex(0, height);     // over to bottom-left corner
-  endShape(CLOSE);
-}
-
-function zone1Contribution(x){
-  return min(x, 0.25*width) * 0.2;
-}
-
-function zone2Contribution(x){
-  return min(max(0, x - 0.25*width), width / 2) * 0.1;
-}
-
-function zone3Contribution(x){
-  return min(max(0, x - 0.50*width), 0.75*width) * 0.2;
-}
-
-function zone4Contribution(x){
-  return min(max(0, x - 0.75*width), width) * 0.4;
+  terrain.draw();
 }

--- a/p5js/water-cycle/app.js
+++ b/p5js/water-cycle/app.js
@@ -2,6 +2,7 @@ let seed;
 let system;
 
 function setup() {
+  pixelDensity(1);
   createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
 

--- a/p5js/water-cycle/app.js
+++ b/p5js/water-cycle/app.js
@@ -1,6 +1,7 @@
 let seed;
 let system;
 let terrain;
+let weatherGrid;
 
 function setup() {
   createCanvas(windowWidth, windowHeight-35);
@@ -12,6 +13,7 @@ function setup() {
 
   let rect = new Rect(0, 0, width/2, height/2);
   terrain = new Terrain2D(rect);
+  weatherGrid = new CellGrid(rect, WeatherCell, 20);
 }
 
 function draw(){

--- a/p5js/water-cycle/classes/cell_viewer.js
+++ b/p5js/water-cycle/classes/cell_viewer.js
@@ -1,0 +1,1 @@
+cell_viewer.js

--- a/p5js/water-cycle/classes/cell_viewer.js
+++ b/p5js/water-cycle/classes/cell_viewer.js
@@ -1,1 +1,20 @@
-cell_viewer.js
+class CellViewer {
+  constructor(){
+    console.log("New cell viewer created");
+  }
+
+  renderCell(cell, x, y, p_nWidth, p_nHeight){
+    noStroke();
+
+    if (cell.air) {
+      fill(system.terrain._colors.sky);
+    } else if (cell.water) {
+      fill(system.terrain._colors.water);
+    } else if (cell.soil) {
+      fill(system.terrain._colors.soil);
+    } else {
+      fill(0);
+    }
+    rect(x, y, p_nWidth, p_nHeight);
+  }
+}

--- a/p5js/water-cycle/classes/system.js
+++ b/p5js/water-cycle/classes/system.js
@@ -1,8 +1,18 @@
 class System {
-  constructor(){ 
+  constructor(){
+    let rect = new Rect(0, 0, width/2, height/2);
+    this.terrain = new Terrain2D(rect);
+    this.cellWidth = 2;
+
+    let weatherPos = new Rect(width/2, 0, width/2, height/2);
+    this.weatherGrid = new CellGrid(weatherPos, WeatherCell, this.cellWidth);
   }
 
   tick(){
     console.log("tock");
   }
-}
+
+  draw(){
+    this.terrain.draw();
+  }
+

--- a/p5js/water-cycle/classes/system.js
+++ b/p5js/water-cycle/classes/system.js
@@ -6,6 +6,8 @@ class System {
 
     let weatherPos = new Rect(width/2, 0, width/2, height/2);
     this.weatherGrid = new CellGrid(weatherPos, WeatherCell, this.cellWidth);
+
+    this.initCellsViaTerrain();
   }
 
   tick(){
@@ -14,5 +16,32 @@ class System {
 
   draw(){
     this.terrain.draw();
+    this.weatherGrid.renderViews();
   }
 
+  initCellsViaTerrain(){
+    // General idea here is to trace downward from above,
+    // determine which type of cell exists at each point
+
+    let tmpCell;
+    let colorTop;
+    let colorBottom;
+    let tmpX; 
+    let tmpY;
+
+    for(let i=0; i<this.weatherGrid.cells.length; i++){
+      tmpCell = this.weatherGrid.cells[i];
+
+      tmpX = tmpCell._col * this.cellWidth + 0.5 * this.cellWidth;
+      tmpY = tmpCell._row * this.cellWidth + 0.5 * this.cellWidth;
+
+      colorTop = P5JsUtils.colorAt(tmpX, tmpY, this.terrain._width);
+
+      tmpCell.air = P5JsUtils.colorsMatch(colorTop, this.terrain._colors.sky);
+      tmpCell.water = P5JsUtils.colorsMatch(colorTop, this.terrain._colors.water);
+      tmpCell.soil = P5JsUtils.colorsMatch(colorTop, this.terrain._colors.soil);
+    }
+  }
+
+
+}

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -4,6 +4,7 @@ class Terrain2D {
     this._y = rect._y;
     this._width = rect._width;
     this._height = rect._height;
+    this._colors = this.colorScheme();
 
     this.gBuffer = createGraphics(this._width, this._height);
     this.render();
@@ -15,16 +16,26 @@ class Terrain2D {
 
   render(){
     this.gBuffer.noStroke();
-    this.gBuffer.fill(170,190,240);
+    this.gBuffer.fill(this._colors.sky);
     this.gBuffer.rect(this._x, this._x, this._width, this._height);
 
     this.renderSlope();
   }
 
+  colorScheme(){
+    return {
+      sky: color(157, 220, 252),
+      water: color(52, 127, 207),
+      soil: color(117, 55, 40),
+      sand: color(232, 210, 131),
+      foliage: color(54, 143, 36)
+    };
+  }
+
   renderSlope(){
     var noiseScale = 0.01;
 
-    this.gBuffer.fill(70,75,10);
+    this.gBuffer.fill(this._colors.soil);
     this.gBuffer.noStroke();
     this.gBuffer.beginShape(); 
 

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -1,0 +1,54 @@
+class Terrain2D {
+  constructor (rect){
+    this._x = rect._x;
+    this._y = rect._y;
+    this._width = rect._width;
+    this._height = rect._height;
+  }
+
+  draw(){
+    noStroke();
+    fill(170,190,240);
+    rect(this._x, this._x, this._width, this._height);
+    this.drawSlope();
+  }
+
+  drawSlope(){
+    var noiseScale = 0.01;
+    
+    fill(70,75,10);
+    noStroke();
+    beginShape(); 
+
+    for (var x = 0; x <= this._width; x += 20) {
+      var y = this._height - 20;
+
+      y -= (  this.zone1Contribution(x)
+            + this.zone2Contribution(x) 
+            + this.zone3Contribution(x) 
+            + this.zone4Contribution(x));
+      y -= noise(x*noiseScale) * 130;
+
+      vertex(x, y); 
+    }
+    vertex(this._width, this._height); // down to bottom-right corner
+    vertex(0, this._height);     // over to bottom-left corner
+    endShape(CLOSE);
+  }
+
+  zone1Contribution(x){
+    return min(x, 0.25*this._width) * 0.2;
+  }
+
+  zone2Contribution(x){
+    return min(max(0, x - 0.25*this._width), this._width / 2) * 0.1;
+  }
+
+  zone3Contribution(x){
+    return min(max(0, x - 0.50*this._width), 0.75*this._width) * 0.2;
+  }
+
+  zone4Contribution(x){
+    return min(max(0, x - 0.75*this._width), this._width) * 0.4;
+  }
+}

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -19,6 +19,7 @@ class Terrain2D {
     this.renderSky();
     this.renderSeaLevel();
     this.renderSlope();
+    this.gBuffer.loadPixels();
   }
 
   colorScheme(){

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -16,9 +16,8 @@ class Terrain2D {
 
   render(){
     this.gBuffer.noStroke();
-    this.gBuffer.fill(this._colors.sky);
-    this.gBuffer.rect(this._x, this._x, this._width, this._height);
-
+    this.renderSky();
+    this.renderSeaLevel();
     this.renderSlope();
   }
 
@@ -30,6 +29,16 @@ class Terrain2D {
       sand: color(232, 210, 131),
       foliage: color(54, 143, 36)
     };
+  }
+
+  renderSky(){
+    this.gBuffer.fill(this._colors.sky);
+    this.gBuffer.rect(this._x, this._y, this._width, this._height);
+  }
+
+  renderSeaLevel(){
+    this.gBuffer.fill(this._colors.water);
+    this.gBuffer.rect(this._x, this._height - 60, this._width, 60);
   }
 
   renderSlope(){
@@ -46,7 +55,7 @@ class Terrain2D {
             + this.zone2Contribution(x) 
             + this.zone3Contribution(x) 
             + this.zone4Contribution(x));
-      y -= noise(x*noiseScale) * 50;
+      y -= noise(x*noiseScale) * 40;
 
       this.gBuffer.vertex(x, y); 
     }

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -28,14 +28,14 @@ class Terrain2D {
     this.gBuffer.noStroke();
     this.gBuffer.beginShape(); 
 
-    for (var x = 0; x <= this._width; x += 20) {
-      var y = this._height - 20;
+    for (var x = 0; x <= this._width; x += 2) {
+      var y = this._height - 10;
 
       y -= (  this.zone1Contribution(x)
             + this.zone2Contribution(x) 
             + this.zone3Contribution(x) 
             + this.zone4Contribution(x));
-      y -= noise(x*noiseScale) * 130;
+      y -= noise(x*noiseScale) * 50;
 
       this.gBuffer.vertex(x, y); 
     }

--- a/p5js/water-cycle/classes/terrain_2d.js
+++ b/p5js/water-cycle/classes/terrain_2d.js
@@ -4,21 +4,29 @@ class Terrain2D {
     this._y = rect._y;
     this._width = rect._width;
     this._height = rect._height;
+
+    this.gBuffer = createGraphics(this._width, this._height);
+    this.render();
   }
 
   draw(){
-    noStroke();
-    fill(170,190,240);
-    rect(this._x, this._x, this._width, this._height);
-    this.drawSlope();
+    image(this.gBuffer, this._x, this._y);
   }
 
-  drawSlope(){
+  render(){
+    this.gBuffer.noStroke();
+    this.gBuffer.fill(170,190,240);
+    this.gBuffer.rect(this._x, this._x, this._width, this._height);
+
+    this.renderSlope();
+  }
+
+  renderSlope(){
     var noiseScale = 0.01;
-    
-    fill(70,75,10);
-    noStroke();
-    beginShape(); 
+
+    this.gBuffer.fill(70,75,10);
+    this.gBuffer.noStroke();
+    this.gBuffer.beginShape(); 
 
     for (var x = 0; x <= this._width; x += 20) {
       var y = this._height - 20;
@@ -29,11 +37,11 @@ class Terrain2D {
             + this.zone4Contribution(x));
       y -= noise(x*noiseScale) * 130;
 
-      vertex(x, y); 
+      this.gBuffer.vertex(x, y); 
     }
-    vertex(this._width, this._height); // down to bottom-right corner
-    vertex(0, this._height);     // over to bottom-left corner
-    endShape(CLOSE);
+    this.gBuffer.vertex(this._width, this._height); // down to bottom-right corner
+    this.gBuffer.vertex(0, this._height);     // over to bottom-left corner
+    this.gBuffer.endShape(CLOSE);
   }
 
   zone1Contribution(x){

--- a/p5js/water-cycle/classes/weather_cell.js
+++ b/p5js/water-cycle/classes/weather_cell.js
@@ -1,5 +1,15 @@
 class WeatherCell {
+  constructor (row, col, system, index) {
+    this._index = index;
+    this._row = row;
+    this._col = col;
+
+    this.air = false;
+    this.water = false;
+    this.soil = false;
+  }
+
   static createCell(row, col, index){
-    
+    return new WeatherCell(row, col, index);
   }
 }

--- a/p5js/water-cycle/classes/weather_cell.js
+++ b/p5js/water-cycle/classes/weather_cell.js
@@ -1,0 +1,5 @@
+class WeatherCell {
+  static createCell(row, col, index){
+    
+  }
+}

--- a/p5js/water-cycle/index.md
+++ b/p5js/water-cycle/index.md
@@ -7,12 +7,15 @@ modal: true
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.23/p5.js
 - /sketchbook/p5js/common/p5js_settings.js
+- /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js
 - /sketchbook/js/options_set.js
 - /sketchbook/js/models/rect.js
 - /sketchbook/js/models/cell_grid.js
 - classes/system.js
 - classes/terrain_2d.js
+- classes/cell_viewer.js
+- classes/weather_cell.js
 - app.js
 
 ---

--- a/p5js/water-cycle/index.md
+++ b/p5js/water-cycle/index.md
@@ -12,6 +12,7 @@ js_scripts:
 - /sketchbook/js/models/rect.js
 - /sketchbook/js/models/cell_grid.js
 - classes/system.js
+- classes/terrain_2d.js
 - app.js
 
 ---


### PR DESCRIPTION
This https://github.com/brianhonohan/sketchbook/commit/6d3bb69f7b9b507edb96262da3204da1ed23bdc7 is probably the primary commit here.

Which is to say this PR derives data from the drawn image into a CellGrid for [FEA (Finite Element analysis](https://en.wikipedia.org/wiki/Finite_element_method).

Notable concept in use there are:

* Using the `pixels` array to detect the presence of air / water / soil based on the color at a particular point.

The others set up / enable that, such as;

* New `P5JsUtils` class to gather some extensions to p5.js (this may be premature optimization, based on the readings of how `get(x, y)` for a color at a pixel isn't performant in some cases).
* Use of `createGraphics(...)` in  https://github.com/brianhonohan/sketchbook/pull/23/commits/8c68b7e78eef866da5ebcd8854b1cd9f2ef392c5 so as to draw the background once, cache it to an image, and just render that image on subsequent draws.