### PR TITLE
p5js - Ecosystem - Fixup grid initialization / drawing

### DIFF
--- a/p5js/ecosystem/app.js
+++ b/p5js/ecosystem/app.js
@@ -10,11 +10,11 @@ function setup() {
 
   logSettings();
   frameRate(1);
-  ecosystem.tick();
 }
 
 function draw() {
   ecosystem.tick();
+  ecosystem.draw();
 }
 
 function logSettings(){

--- a/p5js/ecosystem/classes/ecosystem.js
+++ b/p5js/ecosystem/classes/ecosystem.js
@@ -6,6 +6,7 @@ class Ecosystem {
 
     this.determineMagicWaterPercentageFactor();
     this.grid = new CellGrid(this.sizeAndPosition, this, this.settings.cellWidth);
+    this.grid.initCells();
   }
 
   getScale(){
@@ -149,6 +150,9 @@ class Ecosystem {
     }
 
     this.erode();
+  }
+
+  draw(){
     this.grid.renderViews();
   }
 


### PR DESCRIPTION
* Recently changed how the CellGrid class' constructor behavior to remove the call to initCells(), so now need to call it explicitly.