### PR TITLE
p5js - 3D Flying Camera - Fix bug on non-square canvases

### DIFF
--- a/p5js/3d-flying-camera/3d_flying_camera.js
+++ b/p5js/3d-flying-camera/3d_flying_camera.js
@@ -31,7 +31,7 @@ class CameraController {
 
     
     this.centerX = width / 2;
-    this.centerY = width / 2;
+    this.centerY = height / 2;
 
     this.mouseInactiveZone = 50;
 


### PR DESCRIPTION
* Silly bug, using width in calculation of the centerY value.
* Developed on a square canvas ... so didn't see this until deploying.