### PR TITLE
common - Update p5.js template to use local_dev.html from start

### DIFF
--- a/p5js/sketch-template/README.md
+++ b/p5js/sketch-template/README.md
@@ -1,0 +1,26 @@
+
+## Overview
+
+This is a [p5.js][p5js-home] sketch 
+
+
+## Controls
+
+(No interactivity implemented yet).
+
+# References:
+* 
+
+# Links: 
+
+* [Live View][live-view]
+* [Source on Github][source-code]
+
+# Screenshot:
+
+![screenshot][screenshot-01]
+
+[p5js-home]: http://p5js.org/
+[source-code]: https://github.com/brianhonohan/sketchbook/tree/master/p5js/coding-challenges/mitosis/
+[live-view]: https://brianhonohan.com/sketchbook/p5js/coding-challenges/mitosis/live-view.html
+[screenshot-01]: ./screenshot-01.png

--- a/p5js/sketch-template/index.md
+++ b/p5js/sketch-template/index.md
@@ -19,3 +19,5 @@ js_scripts:
 
 ---
 
+{% include_relative README.md %}
+

--- a/p5js/sketch-template/local_dev.html
+++ b/p5js/sketch-template/local_dev.html
@@ -1,0 +1,1 @@
+local_dev.html


### PR DESCRIPTION
* So I get in the habit of starting with the `local_dev.html`  
  - So that when I produce the `index.md` file, I don't have to rename the `.html` file (and thus split git history across two filenames).