### PR TITLE
p5js - Maze Generator - Refactor references to top and left walls

### DIFF
--- a/_posts/coding-challenges/2018-10-07-coding-challenge-9-solar-system-3d-texturized.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-9-solar-system-3d-texturized.md
@@ -18,7 +18,7 @@ Key learnings:
 
 ## Sample Textures:
 
-Textures were downloaded from [solarsystemscope.com][solar-system-textures] which provides the iamges free of charge for use in 3D models like this sketch.
+Textures were downloaded from [solarsystemscope.com][solar-system-textures] which provides the images free of charge for use in 3D models like this sketch.
 
 [![texture-sample-sun][texture-sun]{:class="img-thumbnail"}][live-view]
 [![texture-sample-earth][texture-earth]{:class="img-thumbnail"}][live-view]

--- a/p5js/coding-challenges/maze-generator/maze_generator.js
+++ b/p5js/coding-challenges/maze-generator/maze_generator.js
@@ -216,18 +216,16 @@ class MazeCell {
   
   static get REJECTED(){ return -2; }
 
-  get leftWall() {
-    return this.cellToLeft.rightWall;
-  }
+  get leftWall() { return this.cellToLeft.rightWall; }
+  set leftWall(state) { this.cellToLeft.rightWall = state; }
 
-  get topWall() {
-    return this.cellAbove.bottomWall;
-  }
+  get topWall() { return this.cellAbove.bottomWall; }
+  set topWall(state) { this.cellAbove.bottomWall = state; }
 
   openWall(wallIdx){
     switch(wallIdx) {
       case 0:
-        this.cellAbove.bottomWall = MazeCell.WALL_OPEN;
+        this.topWall = MazeCell.WALL_OPEN;
         break;
       case 1:
         this.rightWall = MazeCell.WALL_OPEN;
@@ -236,7 +234,7 @@ class MazeCell {
         this.bottomWall = MazeCell.WALL_OPEN;
         break;
       case 3:
-        this.cellToLeft.rightWall = MazeCell.WALL_OPEN;
+        this.leftWall = MazeCell.WALL_OPEN;
         break;
     }
   }
@@ -244,7 +242,7 @@ class MazeCell {
   closeWall(wallIdx){
     switch(wallIdx) {
       case 0:
-        this.cellAbove.bottomWall = MazeCell.WALL_SOLID;
+        this.topWall = MazeCell.WALL_SOLID;
         break;
       case 1:
         this.rightWall = MazeCell.WALL_SOLID;
@@ -253,7 +251,7 @@ class MazeCell {
         this.bottomWall = MazeCell.WALL_SOLID;
         break;
       case 3:
-        this.cellToLeft.rightWall = MazeCell.WALL_SOLID;
+        this.leftWall = MazeCell.WALL_SOLID;
         break;
     }
   }

--- a/p5js/coding-challenges/maze-generator/maze_generator.js
+++ b/p5js/coding-challenges/maze-generator/maze_generator.js
@@ -217,31 +217,11 @@ class MazeCell {
   static get REJECTED(){ return -2; }
 
   get leftWall() {
-    let idxToLeft = this.grid.cellIndexToLeft(this._idx);
-    if (idxToLeft == undefined){
-      return MazeCell.WALL_SOLID;
-    }
-
-    let cell =  this.grid.cells[idxToLeft];
-    if (cell.state == MazeCell.CELL_SOLID){
-      return MazeCell.WALL_SOLID;
-    }else{
-      return cell.rightWall;
-    }
+    return this.cellToLeft.rightWall;
   }
 
   get topWall() {
-    let idxToAbove = this.grid.cellIndexAbove(this._idx);
-    if (idxToAbove == undefined){
-      return MazeCell.WALL_SOLID;
-    }
-
-    let cell =  this.grid.cells[idxToAbove];
-    if (cell.state == MazeCell.CELL_SOLID){
-      return MazeCell.WALL_SOLID;
-    }else{
-      return cell.bottomWall;
-    }
+    return this.cellAbove.bottomWall;
   }
 
   openWall(wallIdx){


### PR DESCRIPTION
* Fully commits to delegating the `topWall` and `leftWall` to the neighbors above and to the left.

The original implementation (which this makes conceptually cleaner) was mostly to have a single representation of shared objects, such that there is a defined pattern of which object owns with of the shared objects.

![image](https://user-images.githubusercontent.com/471054/48655795-d67d7c80-e9e9-11e8-98f7-338551deb99c.png)


