### PR TITLE
p5js - Space Colonization - Fix ties between nutrients

### DIFF
--- a/p5js/coding-challenges/fractal-trees-05/README.md
+++ b/p5js/coding-challenges/fractal-trees-05/README.md
@@ -3,14 +3,14 @@
 
 This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-train] [Coding Challenge #17][ct-challenge-17]  on implmementing the 'Space Colonization' tree growth algorithm, as outlined on [AlgorithmBotany.com][algo-botany-space-colonization].
 
-The gist of it is to imagine the end result of a tree's growth, in terms of lcoation of the leaves ... and allow the branches to grow into that space.
+The gist of it is to imagine the end result of a tree's growth, in terms of location of the leaves ... and allow the branches to grow into those spaces.
 
 This was intended to mimic how roots would grow (and compete) over nutrients in the soil. In reality, plants roots don't detect nutrients and so they don't grow toward them.
 
 From [CropNutrition.com][cropnutrition-how-plants-absorb]
 > Since roots have no special radar, sonar or other device to detect nutrients around the corner or in deeper soil layers, they instead depend on, essentially, the nutrients coming to them.
 
-Some plants do exhibit [Hydrotroism][wikipedia-hydrotropism] in root growth, meaning they grow towards more humid areas.
+Some plants do exhibit [Hydrotropism][wikipedia-hydrotropism] in root growth, meaning they grow towards more humid areas.
 
 ## Controls
 
@@ -20,7 +20,7 @@ Keyboard:
 
 # References:
 * [AlgorithmBotany.com - Space Colonization][algo-botany-space-colonization]
-* [p5.js - `saveCanvas()`][p5js-saveCanvas] Allows to save screenshot of current state.
+* [p5.js - `saveCanvas()`][p5js-saveCanvas] Allows saving a screenshot of current state.
 * [CropNutrition.com - How Plants Absorb Nutrients][cropnutrition-how-plants-absorb]
 * [Wikipedia - Hydrotropism][wikipedia-hydrotropism]
 

--- a/p5js/coding-challenges/fractal-trees-05/classes/root_segment.js
+++ b/p5js/coding-challenges/fractal-trees-05/classes/root_segment.js
@@ -28,8 +28,11 @@ class RootSegment {
     }
 
     let totalPos = createVector(0, 0);
-    let vectorAdder = function(total, n) { total.add(n.pos); return total; };
-    this.targetNutrients.reduce(vectorAdder, totalPos);
+    let randomModifier = function(vector, delta) { vector.mult(random(1-delta, 1+delta)); return vector; }
+    let vectorAdder = function(total, vector) { total.add(vector); return total; };
+    this.targetNutrients
+        .map(nutrient => randomModifier(nutrient.pos.copy(), 0.008))
+        .reduce(vectorAdder, totalPos);
 
     let avgPos = p5.Vector.div(totalPos, this.targetNutrients.length);
 

--- a/p5js/coding-challenges/fractal-trees-05/classes/soil.js
+++ b/p5js/coding-challenges/fractal-trees-05/classes/soil.js
@@ -47,7 +47,7 @@ class Soil {
     nutrientsWithSeg = nutrientsWithSeg.filter(nSeg => nSeg.segments.length > 0);
 
     nutrientsWithSeg.forEach(nSeg => {
-      let closest = 10000000000000000; // intentially very large number
+      let closest = Number.POSITIVE_INFINITY; // intentially very large number
       let idxOfClosest = null;
       for(var i = 0; i < nSeg.segments.length; i++){
         let segment = nSeg.segments[i];


### PR DESCRIPTION
Primary change here is to add a tiebreak to the algorithm of having the `RootSegments` grow based on nearby nutrients.

### Before

Note the blue lines connecting two green squares to a Root Segment. These are effectively "ties".

![space-colonization-before-tiebreak](https://user-images.githubusercontent.com/471054/49705629-bfe3d300-fbed-11e8-8d50-7d3530029ce4.png)

### After

There are no more ties, but the overall paths have changed a bit. (Not sure how I feel about this, but it's pretty small).

![space-colonization-after-tiebreak](https://user-images.githubusercontent.com/471054/49705634-c5411d80-fbed-11e8-9590-443618a73f42.png)


-----

Also includes a minor tweaks:
- README typo fixes.
- And use [`Number.POSITIVE_INFINITY`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY) instead of `100000000000` to denote a large number.