### PR TITLE
Fix typos in READMEs and posts

### DIFF
--- a/_posts/2017-11-04-p5-js-procedural-generation-of-terrain-with-perlin-noise.markdown
+++ b/_posts/2017-11-04-p5-js-procedural-generation-of-terrain-with-perlin-noise.markdown
@@ -55,7 +55,7 @@ That means if we want to translate that elevation above and below sea-level, we 
 * Multiple it by some sort of factor
 * Translate that `0.0 to 1.0` range into values ranging from `-500 to 500`
 
-In this sketch, this is acheived with the following:
+In this sketch, this is achieved with the following:
 
 {% highlight javascript %}
 this.elevation = 500 - 1000 * noise(this._row, this._col);

--- a/_posts/coding-challenges/2018-10-07-coding-challenge-7-solar-system.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-7-solar-system.md
@@ -31,7 +31,7 @@ static forceDueToG(obj1, obj2){
 
 Additionally, it uses values for Mass and Radii based on actual values for the masses of the planets in our solar system.
 
-And, after randomly placing the masses, it determines what their approxiamte orbital velocity based by determing the speed that would generate a [Centripetal Force][wikipedia-centripetal] equal to the gravitational force at that distance.
+And, after randomly placing the masses, it determines what their approximate orbital velocity based by determining the speed that would generate a [Centripetal Force][wikipedia-centripetal] equal to the gravitational force at that distance.
 
 {% highlight javascript %}
 static orbitalV(ofObject, aroundObj){

--- a/_posts/coding-challenges/2018-10-07-coding-challenge-8-solar-system-3d.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-8-solar-system-3d.md
@@ -14,8 +14,8 @@ It builds on the simpler [2D implementation][sketch-solar-system].
 In fact, it was implemented mostly via:
 
   * [Refactor](https://github.com/brianhonohan/sketchbook/pull/34/commits/024b4a570bc71e9a18f463f607be809091d59a6d) away direct knowledge of 2D nature of the system.
-  * [Add 3D Support](https://github.com/brianhonohan/sketchbook/pull/34/commits/79916f2c36b26e769f282b1cc1876cda2eaf4bd3) as via an alterate renderer and vector generator.
-    - Benefitting from the fact that [p5.js Vector][p5js-vector] easily supports both 2D and 3D vectors.  
+  * [Add 3D Support](https://github.com/brianhonohan/sketchbook/pull/34/commits/79916f2c36b26e769f282b1cc1876cda2eaf4bd3) as via an alternate renderer and vector generator.
+    - Benefiting from the fact that [p5.js Vector][p5js-vector] easily supports both 2D and 3D vectors.  
 
 Following the principle put forth by [Kent Beck][twitter-beck-quote]:
 

--- a/_posts/coding-challenges/2018-10-09-coding-challenge-maze-generator.md
+++ b/_posts/coding-challenges/2018-10-09-coding-challenge-maze-generator.md
@@ -11,9 +11,9 @@ This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-trai
 
 [![screenshot-01][screenshot-01]][live-view]
 
-I leaned on some concepts from my CS degree, and implemente a depth-first algorithm, similar to this [recursive-backtracker][wikipedia-recursive-backtracker] noted on Wikipedia.
+I leaned on some concepts from my CS degree, and implemented a depth-first algorithm, similar to this [recursive-backtracker][wikipedia-recursive-backtracker] noted on Wikipedia.
 
-Additionally, this makes use of the common [`CellGrid`][code-cell-grid] class which I created to faciliate navigating a 2D array, and getting neighbors of a particular index.
+Additionally, this makes use of the common [`CellGrid`][code-cell-grid] class which I created to facilitate navigating a 2D array, and getting neighbors of a particular index.
 
 A minor implementation note is the treatment of the outer edges. The first and last rows of the 2D Array, as well as the leftmost and rightmost columns are [treated as "SOLID"][code-solid-edges], and thus appear as black squares in the visual drawing. This allowed the code to not worry about `undefined` neighbors and treat everything as a `MazeCell`.
 

--- a/p5js/coding-challenges/maze-generator/README.md
+++ b/p5js/coding-challenges/maze-generator/README.md
@@ -2,9 +2,9 @@
 
 This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-train] [Coding Challenge #10][ct-challenge-10] (and [part 2][ct-challenge-10-p2], [part 3][ct-challenge-10-p3], [part 4][ct-challenge-10-p4]) on generating a maze.
 
-I leaned on some concepts from my CS degree, and implemente a depth-first algorithm, similar to this [recursive-backtracker][wikipedia-recursive-backtracker] noted on Wikipedia.
+I leaned on some concepts from my CS degree, and implemented a depth-first algorithm, similar to this [recursive-backtracker][wikipedia-recursive-backtracker] noted on Wikipedia.
 
-Additionally, this makes use of the common [`CellGrid`][code-cell-grid] class which I created to faciliate navigating a 2D array, and getting neighbors of a particular index.
+Additionally, this makes use of the common [`CellGrid`][code-cell-grid] class which I created to facilitate navigating a 2D array, and getting neighbors of a particular index.
 
 An interesting implementation note is the treatment of the outer edges. The first and last rows of the 2D Array, as well as the leftmost and rightmost columns are [treated as "SOLID"][code-solid-edges], and thus appear as black squares in the visual drawing. This allowed the code to not worry about `undefined` neighbors and treat everything as a `MazeCell`.
 

--- a/p5js/coding-challenges/solar-system/README.md
+++ b/p5js/coding-challenges/solar-system/README.md
@@ -10,7 +10,7 @@ F = G * m1 * m2 / (r * r)
 
 Additionally, it uses values for Mass and Radii based on actual values for the masses of the planets in our solar system.
 
-And, after randomly placing the masses, it determines what their approxiamte orbital velocity based by determing the speed that would generate a [Centripetal Force][wikipedia-centripetal] equal to the gravitational force at that distance.
+And, after randomly placing the masses, it determines what their approximate orbital velocity based by determining the speed that would generate a [Centripetal Force][wikipedia-centripetal] equal to the gravitational force at that distance.
 
 Caveat: The objects only experience the gravitational attraction of the "sun" at the center; which in turn does not experience any gravitational force. This allows for a stable system, but lacks the interplay of forces in a true [n-body simulation][wikipedia-n-body-sim].
 


### PR DESCRIPTION
I've since [enabled spell check by default in Sublime (juristr.com)](https://juristr.com/blog/2014/11/enable-spell-check-sublime-markdown/) to catch these earlier moving forward.