### PR TITLE
p5js/scales - Fix Circle-Line sketch

### DIFF
--- a/p5js/scales/circle_line_intersection.html
+++ b/p5js/scales/circle_line_intersection.html
@@ -9,6 +9,7 @@
     <script src="/sketchbook/js/models/quadratic_equation.js" charset="utf-8"></script>
     <script src="/sketchbook/p5js/common/geometry/circle_line_intersection.js" charset="utf-8"></script>
     <script src="/sketchbook/p5js/common/shapes/line_segment.js" charset="utf-8"></script>
+    <script src="/sketchbook/p5js/common/shapes/point.js" charset="utf-8"></script>
     <script src="/sketchbook/p5js/common/shapes/circle.js" charset="utf-8"></script>
     <script src="circle_line_intersection.js" charset="utf-8"></script>
 


### PR DESCRIPTION
Missing `<script>` include ...

Should fix:
https://brianhonohan.com/sketchbook/p5js/scales/circle_line_intersection.html