### PR TITLE
p5js/forest - Adjust config and intialization

### DIFF
--- a/p5js/common/p5js_settings.js
+++ b/p5js/common/p5js_settings.js
@@ -23,4 +23,48 @@ class P5JsSettings {
     console.log("P5JS Settings: ");
     console.log(this.optionsSet.settings);
   }
+
+  static addDatGui(datGuiParams){
+    datGuiParams = datGuiParams || {};
+    const datGui = new dat.gui.GUI(datGuiParams);
+
+    if (datGuiParams.autoPlace === false) {
+      this.datGuiContainer = this.createDatGuiContainer();
+      this.datGuiContainer.appendChild(datGui.domElement);
+
+      document.addEventListener('keyup', function(event){
+        if (event.key === 'h') {
+          P5JsSettings.toggleDatGuiHide();
+        }
+      });
+    }
+    return datGui;
+  }
+
+  static toggleDatGuiHide(){
+    if (this.datGuiContainer.style.display === "none") {
+      this.datGuiContainer.style.display = "block";
+    } else {
+      this.datGuiContainer.style.display = "none";
+    }
+  }
+
+  static createDatGuiContainer(){
+    let container = document.createElement("div"); 
+    container.setAttribute('id', 'datGuiContainer');
+    container.style.position = 'absolute';
+    container.style.right = '0px';
+    container.style.bottom = '20px';
+
+    let label = document.createElement('div');
+    label.style.color = 'white';
+    label.style.backgroundColor = 'black';
+    label.style.padding = '5px';
+    label.style.font = "11px 'Lucida Grande',sans-serif";
+    label.innerHTML = "Config (Press H to Hide/Show)";
+    container.appendChild(label);
+
+    document.body.appendChild(container);
+    return container;
+  }
 }

--- a/p5js/forest-01/app.js
+++ b/p5js/forest-01/app.js
@@ -1,6 +1,7 @@
 var system;
 
 var gui;
+var guiContainer;
 var systemParams = {
   foraging_rate: 0.6,
   seeds_per_tree: 2,
@@ -18,7 +19,11 @@ function setup() {
   createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
 
-  gui = new dat.gui.GUI();
+  guiContainer = createDatGuiContainer();
+
+  gui = new dat.gui.GUI({ autoPlace: false });
+  guiContainer.appendChild(gui.domElement);
+
   gui.add(systemParams, 'foraging_rate').min(0.1).max(0.9).step(0.05);
   gui.add(systemParams, 'seeds_per_tree').min(1).max(20).step(1);
   gui.add(systemParams, 'seed_drop_dist').min(1).max(150).step(10);
@@ -39,6 +44,9 @@ function keyPressed() {
   if (key === 'c'){
     P5JsSettings.init();
     system.init();
+  } else if (key === 'h'){
+    console.log()
+    toggleDatGuiHide();
   } else if (key === 't'){
     system.forest.sproutTree(mouseX, mouseY);
   }
@@ -48,4 +56,22 @@ function draw(){
   background(50);
   system.tick();
   system.render();
+}
+
+function createDatGuiContainer(){
+  let container = document.createElement("div"); 
+  container.setAttribute('id', 'datGuiContainer');
+  container.style.position = 'absolute';
+  container.style.right = '0px';
+  container.style.bottom = '20px';
+  document.body.appendChild(container);
+  return container;
+}
+
+function toggleDatGuiHide() {
+  if (guiContainer.style.display === "none") {
+    guiContainer.style.display = "block";
+  } else {
+    guiContainer.style.display = "none";
+  }
 }

--- a/p5js/forest-01/app.js
+++ b/p5js/forest-01/app.js
@@ -1,7 +1,6 @@
 var system;
 
 var gui;
-var guiContainer;
 var systemParams = {
   foraging_rate: 0.6,
   seeds_per_tree: 2,
@@ -19,11 +18,7 @@ function setup() {
   createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
 
-  guiContainer = createDatGuiContainer();
-
-  gui = new dat.gui.GUI({ autoPlace: false });
-  guiContainer.appendChild(gui.domElement);
-
+  gui = P5JsSettings.addDatGui({autoPlace: false});
   gui.add(systemParams, 'foraging_rate').min(0.1).max(0.9).step(0.05);
   gui.add(systemParams, 'seeds_per_tree').min(1).max(20).step(1);
   gui.add(systemParams, 'seed_drop_dist').min(1).max(150).step(10);
@@ -44,9 +39,6 @@ function keyPressed() {
   if (key === 'c'){
     P5JsSettings.init();
     system.init();
-  } else if (key === 'h'){
-    console.log()
-    toggleDatGuiHide();
   } else if (key === 't'){
     system.forest.sproutTree(mouseX, mouseY);
   }
@@ -56,31 +48,4 @@ function draw(){
   background(50);
   system.tick();
   system.render();
-}
-
-function createDatGuiContainer(){
-  let container = document.createElement("div"); 
-  container.setAttribute('id', 'datGuiContainer');
-  container.style.position = 'absolute';
-  container.style.right = '0px';
-  container.style.bottom = '20px';
-
-  let label = document.createElement('div');
-  label.style.color = 'white';
-  label.style.backgroundColor = 'black';
-  label.style.padding = '5px';
-  label.style.font = "11px 'Lucida Grande',sans-serif";
-  label.innerHTML = "Config (Press H to Hide/Show)";
-  container.appendChild(label);
-
-  document.body.appendChild(container);
-  return container;
-}
-
-function toggleDatGuiHide() {
-  if (guiContainer.style.display === "none") {
-    guiContainer.style.display = "block";
-  } else {
-    guiContainer.style.display = "none";
-  }
 }

--- a/p5js/forest-01/app.js
+++ b/p5js/forest-01/app.js
@@ -5,6 +5,7 @@ var systemParams = {
   foraging_rate: 0.6,
   seeds_per_tree: 2,
   seed_drop_dist: 70,
+  initial_trees: 10,
   paused: false,
   tree: {
     max_age: 200,
@@ -22,6 +23,7 @@ function setup() {
   gui.add(systemParams, 'foraging_rate').min(0.1).max(0.9).step(0.05);
   gui.add(systemParams, 'seeds_per_tree').min(1).max(20).step(1);
   gui.add(systemParams, 'seed_drop_dist').min(1).max(150).step(10);
+  gui.add(systemParams, 'initial_trees').min(1).max(50).step(1);
   gui.add(systemParams, "paused");
 
   let treeCfg = gui.addFolder('Tree Attributes');

--- a/p5js/forest-01/app.js
+++ b/p5js/forest-01/app.js
@@ -64,6 +64,15 @@ function createDatGuiContainer(){
   container.style.position = 'absolute';
   container.style.right = '0px';
   container.style.bottom = '20px';
+
+  let label = document.createElement('div');
+  label.style.color = 'white';
+  label.style.backgroundColor = 'black';
+  label.style.padding = '5px';
+  label.style.font = "11px 'Lucida Grande',sans-serif";
+  label.innerHTML = "Config (Press H to Hide/Show)";
+  container.appendChild(label);
+
   document.body.appendChild(container);
   return container;
 }

--- a/p5js/forest-01/classes/forest.js
+++ b/p5js/forest-01/classes/forest.js
@@ -5,13 +5,20 @@ class Forest {
     this.params = system.params;
     this.trees = [];
     this.treeCounter = 0;
-    this.sproutTree(this.centerX, this.centerY);
+
+    for (var i = 0; i < this.params.initial_trees; i++){
+      let tmpX = this.centerX + (random() - 0.5) * this.width * 0.8;
+      let tmpY = this.centerY + (random() - 0.5) * this.height * 0.8;
+      this.sproutTree(tmpX, tmpY);
+    }
 
     this.prevSeason = undefined;
   }
 
   get centerX() { return this.area.centerX; }
   get centerY() { return this.area.centerY; }
+  get width()  { return this.area._width; }
+  get height() { return this.area._height; }
 
   sproutTree(x, y){
     this.trees.push( new Tree(x, y, 0, this.treeCounter++) );

--- a/p5js/forest-01/classes/system.js
+++ b/p5js/forest-01/classes/system.js
@@ -4,8 +4,6 @@ class System {
     this.params = params;
     this.optionsSet = new OptionsSet(this.optionsMetadata());
     this.settings = this.optionsSet.settings;
-
-    this.init();
   }
 
   toggleRunning(){


### PR DESCRIPTION
Minor changes overall.

This moves the dat.gui config to the bottom right of the screen (to not obscure the top nav on https://brianhonohan.com/sketchbook/p5js/forest-01/)

Also, establishes an `initial_trees` parameter to have more than 1 tree (which may be eaten) at the start.