### PR TITLE
p5js - Nautical Flags - Add welcome screen and secondary NATO flags

### DIFF
--- a/p5js/nautical-flags/README.md
+++ b/p5js/nautical-flags/README.md
@@ -13,10 +13,28 @@ This is a [p5.js][p5js-home] sketch that allows you to type letters and numbers 
     - `SHIFT` + `0-9` Will show the NATO variant of the [number][wiki-int-numbers].
     - `CTRL` + `1-4` Will show the [Substitute flags][wiki-int-substitute], 1 -4, when you don't have enough flags of one letter.
     - `.` Will show the CODE flag, also known as the 'Answering Pennant', used to start a response to request or as a decimal point.
+    - `CTRL` + Two-Char code for special flags.
+        - `FL` For Flotilla.
+        - `SQ` For Squadron.
+        - `DI` For Division.
+        - `SU` For Subdivision.
+        - `PR` For Preparative.
+        - `IN` For Interrogative.
+        - `NE` For Negative.
+        - `SC` For Screen.
+        - `FO` For Formation.
+        - `CO` For Corpen (Course Pennant)
+        - `TU` For Turn.
+        - `SB` For Starboard.
+        - `PO` For Port.
+        - `SP` For Speed.
+        - `ST` For Station.
+        - `EM` For Emergency.
+        - `DE` For Designation.
 
 # References
 
-Multiple sources were used in 
+Multiple sources were used in determining proportions of the flags.
 
 * Flag Shapes and Meanings:
     - Wikipedia: [International maritime signal flags][wikipedia-int-maritime]
@@ -29,6 +47,7 @@ Multiple sources were used in
     - [Semaphore Flag Signaling][au-semaphore-flags] - How other signal flags are used with a signaler holding two of the same flags in their two arms in different patterns to convey the alphabet and other signals.
     - [Special NATO flags][marinewaypoints.com] - Includes details of secondary flags used by NATO in regards to maneuvering.
     - [International Flags][reddit-int-flags] - Another visual reference.
+
 
 # Links: 
 

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -26,9 +26,9 @@ function showIntroScreen(){
   const marginX = 0.2 * width;
 
   textSize(32);
-  text('Welcome', marginX, 0.2 * height, width - 2 * marginX, height / 3);
+  text('Welcome', marginX, 0.25 * height, width - 2 * marginX, height / 3);
 
-  nauticalFlags.text('WELCOME');
+  nauticalFlags.text('WELCOME', undefined, 100);
   const instructions = 'Type on your keyboard to see the corresponding nautical flag.';
   textSize(20);
   const mainBlockY = height / 2;

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -5,7 +5,7 @@ function setup() {
   P5JsSettings.init();
 
   nauticalFlags = new NauticalFlags(width * 0.6);
-  background(50);
+  showIntroScreen();
 }
 
 function keyTyped(){
@@ -16,4 +16,20 @@ function keyTyped(){
     default:
       nauticalFlags.handleKeyPressed();
   }
+}
+
+function showIntroScreen(){
+  background(50);
+  fill(230);
+  textFont('Verdana');
+  textAlign(CENTER, CENTER);
+  const marginX = 0.2 * width;
+
+  textSize(32);
+  text('Welcome', marginX, 0.2 * height, width - 2 * marginX, height / 3);
+
+  const instructions = 'Type on your keyboard to see the corresponding nautical flag.';
+  textSize(20);
+  const mainBlockY = height / 2;
+  text(instructions, marginX, mainBlockY, width - 2 * marginX, height / 3);
 }

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -13,9 +13,15 @@ function keyTyped(){
     case 'P':
       saveCanvas(canvas, 'screenshot', 'png');
       break;
-    default:
-      nauticalFlags.handleKeyPressed();
   }
+}
+
+function keyPressed(){
+  nauticalFlags.handleKeyPressed();
+}
+
+function keyReleased(){
+  nauticalFlags.handleKeyReleased();
 }
 
 function showIntroScreen(){

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -28,8 +28,10 @@ function showIntroScreen(){
   textSize(32);
   text('Welcome', marginX, 0.2 * height, width - 2 * marginX, height / 3);
 
+  nauticalFlags.text('WELCOME');
   const instructions = 'Type on your keyboard to see the corresponding nautical flag.';
   textSize(20);
   const mainBlockY = height / 2;
   text(instructions, marginX, mainBlockY, width - 2 * marginX, height / 3);
 }
+

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -17,6 +17,9 @@ function keyTyped(){
 }
 
 function keyPressed(){
+  if (key == 'P') {
+    return;
+  }
   nauticalFlags.handleKeyPressed();
 }
 

--- a/p5js/nautical-flags/app.js
+++ b/p5js/nautical-flags/app.js
@@ -1,7 +1,7 @@
 var nauticalFlags;
 
 function setup() {
-  createCanvas(500, 500);
+  createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
 
   nauticalFlags = new NauticalFlags(width * 0.6);

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -18,7 +18,8 @@ class NauticalFlags {
       blue: color(50, 50, 240),
       red: color(240, 50, 50),
       yellow: color(230, 230, 50),
-      black: color(10)
+      black: color(10),
+      green: color(50, 200, 50)
     };
   }
 
@@ -665,8 +666,7 @@ class NauticalFlags {
 
     beginShape();
     let yVal =  (this.pennant.topLeftY + this.pennant.slope * x);
-    yVal = constrain(yVal, minY, maxY);
-    vertex(x, yVal);
+    vertex(x, constrain(yVal, minY, maxY));
 
     yVal += this.pennant.slope * barWidth;
     yVal = constrain(yVal, minY, maxY);
@@ -990,5 +990,55 @@ class NauticalFlags {
     rect(0, this.flagWidth / 2, barWidth, barHeight);
 
     this.drawBarInTriangle(barWidth, barWidth, undefined, this.flagWidth / 2 + barHeight);
+  }
+
+  drawSpecialIN(){
+    fill(this.colors.white);
+    this.drawPennantBase();
+
+    fill(this.colors.red);
+    this.drawBarInPennant(this.flagWidth / 2, this.flagWidth / 2);
+  }
+
+  drawSpecialNE(){
+    fill(this.colors.blue);
+    this.drawPennantBase();
+
+    fill(this.colors.yellow);
+    const barWidth = this.flagWidth / 4;
+    this.drawBarInPennant(barWidth, barWidth, this.flagWidth / 2);
+    this.drawBarInPennant(3 * barWidth, barWidth, this.flagWidth / 2);
+
+    this.drawBarInPennant(0, barWidth, undefined, this.flagWidth / 2);
+    this.drawBarInPennant(2 * barWidth, barWidth,  undefined, this.flagWidth / 2);
+  }
+
+  drawSpecialTU(){
+    fill(this.colors.white);
+    this.drawPennantBase();
+
+    fill(this.colors.blue);
+    const barWidth = this.flagWidth / 6;
+    this.drawBarInPennant(barWidth, barWidth);
+    this.drawBarInPennant(3 * barWidth, barWidth);
+    this.drawBarInPennant(5 * barWidth, barWidth);
+  }
+
+  drawSpecialSB(){
+    fill(this.colors.green);
+    this.drawPennantBase();
+
+    fill(this.colors.white);
+    const barWidth = this.flagWidth / 3;
+    this.drawBarInPennant(barWidth, barWidth);
+  }
+
+  drawSpecialDE(){
+    fill(this.colors.white);
+    this.drawPennantBase();
+
+    fill(this.colors.blue);
+    const barWidth = this.flagWidth / 3;
+    this.drawBarInPennant(barWidth, barWidth);
   }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -31,6 +31,37 @@ class NauticalFlags {
     pop();
   }
 
+  setTempWidth(newWidth){ 
+    this.oldWidth = this.flagWidth;
+    this.flagWidth = newWidth;
+  }
+  restoreOldWidth(){
+    this.flagWidth = this.oldWidth;
+  }
+
+  text(str){
+    const margin = 0.2 * width;
+    const displayWidth = width - 2 * margin;
+
+    const letterWidth = displayWidth / str.length;
+
+    this.setTempWidth(0.9 * letterWidth);
+    const letterSpacing = letterWidth - this.flagWidth;
+
+    noStroke();
+    push();
+    translate(margin, height / 2 - this.flagWidth / 2);
+    const symbols = str.split('');
+
+    for(var i = 0; i < symbols.length; i++){
+      let renderMethodName = this.renderMethodFor(symbols[i]);
+      this[renderMethodName]();
+      translate(this.flagWidth + letterSpacing, 0);
+    }
+    pop();
+    this.restoreOldWidth();
+  }
+
   renderMethodFor(key){
     if (keyIsDown(CONTROL)){
       if (key >= '1' && key <= '4'){

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -886,4 +886,28 @@ class NauticalFlags {
     fill(this.colors.blue);
     rect(0, 0, subSquareWidth, subSquareWidth);
   }
+
+  drawSpecialDI(){
+    fill(this.colors.red);
+    rect(0, 0, this.flagWidth, this.flagWidth);
+
+    const barHeight = this.flagWidth / 4;
+    fill(this.colors.white);
+    rect(0, barHeight, this.flagWidth, barHeight);
+    fill(this.colors.blue);
+    rect(0, 2 * barHeight, this.flagWidth, barHeight);
+    fill(this.colors.yellow);
+    rect(0, 3 * barHeight, this.flagWidth, barHeight);
+  }
+
+  drawSpecialPO(){
+    fill(this.colors.red);
+    rect(0, 0, this.flagWidth, this.flagWidth);
+
+    const barWidth = this.flagWidth / 7;
+    fill(this.colors.white);
+    rect(barWidth, 0, barWidth, this.flagWidth);
+    rect(3 * barWidth, 0, barWidth, this.flagWidth);
+    rect(5 * barWidth, 0, barWidth, this.flagWidth);
+  }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -910,4 +910,29 @@ class NauticalFlags {
     rect(3 * barWidth, 0, barWidth, this.flagWidth);
     rect(5 * barWidth, 0, barWidth, this.flagWidth);
   }
+
+  drawSpecialTriangleBase(){
+    this.drawSubstituteBase();
+  }
+
+  drawSpecialSU(){
+    fill(this.colors.blue);
+    this.drawSpecialTriangleBase();
+  }
+
+  drawSpecialSP(){
+    fill(this.colors.red);
+    this.drawSpecialTriangleBase();
+  }
+
+  drawSpecialST(){
+    fill(this.colors.red);
+    this.drawSpecialTriangleBase();
+
+    fill(this.colors.white);
+    const innerBaseHeight = this.getSubstitudeBaseHeight() / 2;
+    triangle(0, this.flagWidth / 2 - innerBaseHeight / 2,
+             this.flagWidth / 2, this.flagWidth / 2,
+             0, this.flagWidth / 2 + innerBaseHeight / 2);
+  }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -1081,4 +1081,31 @@ class NauticalFlags {
     const dia2 = 0.75 * dia1;
     ellipse(2 * dia1 + 0.5 * dia2, this.flagWidth / 2, dia2, dia2);
   }
+
+  drawSpecialFL(){
+    const swallowtailIndent = this.flagWidth / 3;
+    const swallowtailSlope = (this.flagWidth / 2) / swallowtailIndent;
+
+    fill(this.colors.blue);
+
+    beginShape();
+    vertex(0, 0);
+    vertex(this.flagWidth, 0);
+    vertex(this.flagWidth - swallowtailIndent, this.flagWidth/2);
+    vertex(this.flagWidth, this.flagWidth);
+    vertex(0, this.flagWidth);
+    endShape();
+
+    const barHeight = 0.5 * this.flagWidth;
+    const barMaxX = this.flagWidth - swallowtailIndent+ (barHeight /2) / swallowtailSlope;
+
+    fill(this.colors.white);
+    beginShape();
+    vertex(0, barHeight / 2);
+    vertex(barMaxX, barHeight / 2);
+    vertex(this.flagWidth - swallowtailIndent, this.flagWidth/2);
+    vertex(barMaxX, this.flagWidth / 2+ barHeight / 2);
+    vertex(0, this.flagWidth / 2 + barHeight / 2);
+    endShape();
+  }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -3,6 +3,7 @@ class NauticalFlags {
     this.flagWidth = flagWidth || 300;
     this.initColors();
     this.initPennantCoords();
+    this.initTriangleCoords();
 
     this.mode = NauticalFlags.MODE_NORMAL;
     this.keyBuffer = [];
@@ -802,11 +803,23 @@ class NauticalFlags {
   }
 
   drawSubstituteBase(){
+    triangle(this.triangle.x1, this.triangle.y1,
+        this.triangle.x2, this.triangle.y2,
+        this.triangle.x3, this.triangle.y3);
+  }
+
+  initTriangleCoords(){
     const baseHeight = this.getSubstitudeBaseHeight();
 
-    triangle(0, this.flagWidth / 2 - baseHeight / 2,
-             this.flagWidth, this.flagWidth / 2,
-             0, this.flagWidth / 2 + baseHeight / 2);
+    this.triangle = {
+      baseHeight: baseHeight,
+      x1: 0, 
+      y1: this.flagWidth / 2 - baseHeight / 2,
+      x2: this.flagWidth,
+      y2: this.flagWidth / 2,
+      x3: 0,
+      y3: this.flagWidth / 2 + baseHeight / 2
+    };
   }
 
   drawSubstitute1(){

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -820,6 +820,9 @@ class NauticalFlags {
       x3: 0,
       y3: this.flagWidth / 2 + baseHeight / 2
     };
+
+    this.triangle.slope = (this.triangle.y2 - this.triangle.y1) / 
+                          (this.triangle.x2 - this.triangle.x1);
   }
 
   drawSubstitute1(){
@@ -947,5 +950,45 @@ class NauticalFlags {
     triangle(0, this.flagWidth / 2 - innerBaseHeight / 2,
              this.flagWidth / 2, this.flagWidth / 2,
              0, this.flagWidth / 2 + innerBaseHeight / 2);
+  }
+
+  drawBarInTriangle(x, barWidth, maxY, minY){
+    minY = (minY == undefined) ? Number.NEGATIVE_INFINITY : minY;
+    maxY = (maxY == undefined) ? Number.POSITIVE_INFINITY : maxY;
+
+    beginShape();
+    let yVal =  (this.triangle.y1 + this.triangle.slope * x);
+    vertex(x, constrain(yVal, minY, maxY));
+
+    yVal += this.triangle.slope * barWidth;
+    yVal = constrain(yVal, minY, maxY);
+    vertex(x + barWidth, yVal);
+
+    yVal = (this.triangle.y3 + this.triangle.slope * (x + barWidth) * -1);
+    yVal = constrain(yVal, minY, maxY);
+    vertex(x + barWidth, yVal);
+
+    yVal += this.triangle.slope * barWidth; // (leaving out two negative signs)
+    yVal = constrain(yVal, minY, maxY);
+    vertex(x, yVal);
+    endShape();
+  }
+
+  drawSpecialEM(){
+    fill(this.colors.red);
+    this.drawSpecialTriangleBase();
+
+    fill(this.colors.white);
+    const barWidth = this.flagWidth / 4;
+    const barHeight = this.triangle.baseHeight / 4;
+    this.drawBarInTriangle(0, barWidth, this.flagWidth / 2 - barHeight);
+
+    this.drawBarInTriangle(barWidth * 3, barWidth, this.flagWidth / 2);
+    this.drawBarInTriangle(barWidth * 2, barWidth, undefined, this.flagWidth / 2);
+
+    rect(barWidth, this.flagWidth / 2 - barHeight, barWidth, barHeight);
+    rect(0, this.flagWidth / 2, barWidth, barHeight);
+
+    this.drawBarInTriangle(barWidth, barWidth, undefined, this.flagWidth / 2 + barHeight);
   }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -874,6 +874,8 @@ class NauticalFlags {
     const baseHeightPct = 0.5;
     const tipHeightPct = 0.15;
 
+    this.pennant.baseHeight = baseHeightPct * this.flagWidth;
+
     this.pennant.topLeftX = 0;
     this.pennant.topLeftY = baseHeightPct * 0.5 * this.flagWidth;
 
@@ -1061,5 +1063,22 @@ class NauticalFlags {
 
     fill(this.colors.blue);
     this.drawBarInPennant(0, this.flagWidth, undefined, this.flagWidth / 2 + barHeight / 2);
+  }
+
+  drawSpecialSC(){
+    fill(this.colors.black);
+    this.drawPennantBase();
+  }
+
+  drawSpecialCO(){
+    fill(this.colors.red);
+    this.drawPennantBase();
+
+    fill(this.colors.white);
+    const dia1 = 0.5 * this.pennant.baseHeight;
+    ellipse(dia1, this.flagWidth / 2, dia1, dia1);
+
+    const dia2 = 0.75 * dia1;
+    ellipse(2 * dia1 + 0.5 * dia2, this.flagWidth / 2, dia2, dia2);
   }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -1041,4 +1041,25 @@ class NauticalFlags {
     const barWidth = this.flagWidth / 3;
     this.drawBarInPennant(barWidth, barWidth);
   }
+
+  drawSpecialPR(){
+    fill(this.colors.yellow);
+    this.drawPennantBase();
+
+    const barHeight = 0.8 * Math.abs(this.pennant.topRightY - this.pennant.bottomRightY);
+    fill(this.colors.green);
+    rect(0, this.flagWidth / 2 - barHeight / 2, this.flagWidth, barHeight);
+  }
+
+  drawSpecialFO(){
+    fill(this.colors.red);
+    this.drawPennantBase();
+
+    const barHeight = 0.8 * Math.abs(this.pennant.topRightY - this.pennant.bottomRightY);
+    fill(this.colors.white);
+    rect(0, this.flagWidth / 2 - barHeight / 2, this.flagWidth, barHeight);
+
+    fill(this.colors.blue);
+    this.drawBarInPennant(0, this.flagWidth, undefined, this.flagWidth / 2 + barHeight / 2);
+  }
 }

--- a/p5js/nautical-flags/classes/nautical_flags.js
+++ b/p5js/nautical-flags/classes/nautical_flags.js
@@ -39,8 +39,8 @@ class NauticalFlags {
     this.flagWidth = this.oldWidth;
   }
 
-  text(str){
-    const margin = 0.2 * width;
+  text(str, x, y){
+    const margin = 0.1 * width;
     const displayWidth = width - 2 * margin;
 
     const letterWidth = displayWidth / str.length;
@@ -50,7 +50,9 @@ class NauticalFlags {
 
     noStroke();
     push();
-    translate(margin, height / 2 - this.flagWidth / 2);
+    x = x || margin;
+    y = y || height / 2 - this.flagWidth / 2;
+    translate(x, y);
     const symbols = str.split('');
 
     for(var i = 0; i < symbols.length; i++){

--- a/p5js/nautical-flags/index.md
+++ b/p5js/nautical-flags/index.md
@@ -1,0 +1,20 @@
+---
+layout: minimal
+title:  "P5.JS - Nautical Flags"
+categories: p5js
+modal: true
+
+js_scripts:
+- https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.js
+- /sketchbook/vendor/dat.gui/0.7.3/dat.gui.js
+- /sketchbook/p5js/common/p5js_settings.js
+- /sketchbook/p5js/common/p5js_utils.js
+- /sketchbook/js/util_functions.js
+- /sketchbook/js/options_set.js
+- /sketchbook/js/models/rect.js
+- classes/nautical_flags.js
+- app.js
+
+---
+
+{% include_relative README.md %}


### PR DESCRIPTION
This adds a simple welcome screen.

![screenshot (41)](https://user-images.githubusercontent.com/471054/63656599-02d9dc80-c764-11e9-83a4-f22dbc6aaad2.png)

# Special NATO Flags
Additionally added rendering of 'Special NATO' flags,
http://www.marinewaypoints.com/learn/flags/flags.shtml

Examples:
## Squadron
![screenshot-SQ](https://user-images.githubusercontent.com/471054/63656715-bdb6aa00-c765-11e9-864c-e728d4ef7aea.png)

## Negative
![screenshot-NE](https://user-images.githubusercontent.com/471054/63656716-bdb6aa00-c765-11e9-837c-78b14042773d.png)

## Starboard
![screenshot-SB](https://user-images.githubusercontent.com/471054/63656704-95c74680-c765-11e9-89e8-c7198a09b4b4.png)

## Emergency
![screenshot-EM](https://user-images.githubusercontent.com/471054/63656705-95c74680-c765-11e9-9413-e46c90b92ac8.png)

## Preparative
![screenshot-PR](https://user-images.githubusercontent.com/471054/63656706-95c74680-c765-11e9-8905-2f9add9992f4.png)
