### PR TITLE
p5js/nautical-flags-02 - Adjust trigger for screenshot

### DIFF
--- a/p5js/nautical-flags-02/README.md
+++ b/p5js/nautical-flags-02/README.md
@@ -7,7 +7,7 @@ This is a [p5.js][p5js-home] sketch that allows you to type a message using the 
 ## Controls
 
 * Keyboard:
-    - `SHIFT` + `P` Will save the canvas as a PNG to your computer.
+    - `[` Will save the canvas as a PNG to your computer.
     - `A` - `Z` By themselves will show the flag for that [letter][wiki-int-letters].
     - `0` - `9` By themselves will show the flag for that [number][wiki-int-numbers].
     - `SHIFT` + `0-9` Will show the NATO variant of the [number][wiki-int-numbers].

--- a/p5js/nautical-flags-02/app.js
+++ b/p5js/nautical-flags-02/app.js
@@ -46,18 +46,14 @@ function draw(){
 
 function keyTyped(){
   switch (key) {
-    case 'P':
+    case '[':
       saveCanvas(canvas, 'screenshot', 'png');
       break;
   }
 }
 
 function keyPressed(){
-  if (key == 'P') {
-    return;
-  } else {
-    return !ui.handleKeyPressed();
-  }
+  return !ui.handleKeyPressed();
 }
 
 function mouseReleased(event){


### PR DESCRIPTION
By default, the <input> on iOS is with the Capslock on ... resulting in a 'P' being sent on typing the P key, and then triggering the screenshot generation.

This alters the button to a more obscure `[` key.