### PR TITLE
p5js/common/shapes - Refactor setting of style options

### DIFF
--- a/p5js/common/examples/bezier/app.js
+++ b/p5js/common/examples/bezier/app.js
@@ -53,6 +53,7 @@ function resetShapes(){
   bezierCurve.dragEnabled = true;
   // bezierCurve.makeLinear();
   // bezierCurve.move(150, 180);
+  bezierCurve.strokeColor = color(255);
   shapes.push(bezierCurve);
 
   polybezier = new Polybezier();
@@ -71,6 +72,8 @@ function resetShapes(){
   polybezier.close();
   polybezier.smooth(Polybezier.SMOOTH_MODE_TRAILING);
   polybezier.dragEnabled = true;
+  polybezier.noFill = true;
+  polybezier.strokeColor = color(255);
   shapes.push(polybezier);
 
   bezierCircle = Polybezier.circle(0.7 * width, 0.5 * height, 0.15 * width);

--- a/p5js/common/examples/paisley/app.js
+++ b/p5js/common/examples/paisley/app.js
@@ -32,3 +32,12 @@ function mouseReleased(){
   shapes.filter(s => s.isDragged == true)
         .forEach(s => s.handleMouseReleased());
 }
+
+function keyPressed(){
+  switch(key){
+    case 'c':
+      shapes.filter(s => s.isDragged == true)
+            .forEach(s => console.log(s._constructorCall()));
+      break;
+  }
+}

--- a/p5js/common/examples/paisley/app.js
+++ b/p5js/common/examples/paisley/app.js
@@ -9,6 +9,7 @@ function setup() {
 
   paisley = new Paisley(0.3 * width, 0.5 * height, HALF_PI + QUARTER_PI, 0.1 * width);
   paisley.dragEnabled = true;
+  paisley.fillColor = color(255);
   shapes.push(paisley);
 }
 

--- a/p5js/common/p5js_utils.js
+++ b/p5js/common/p5js_utils.js
@@ -189,4 +189,12 @@ class P5JsUtils {
 
     tmpCanvas.parentNode.removeChild(tmpCanvas);
   }
+
+  static applyStyleSet(styleSet){
+    if (styleSet.fillColor) { fill(styleSet.fillColor); }
+    if (styleSet.noFill) { noFill(); }
+    if (styleSet.strokeColor) { stroke(styleSet.strokeColor); }
+    if (styleSet.noStroke) { noStroke(); }
+    if (styleSet.strokeWeight) { strokeWeight(styleSet.strokeWeight); }
+  }
 }

--- a/p5js/common/shapes/bezier_curve.js
+++ b/p5js/common/shapes/bezier_curve.js
@@ -16,6 +16,7 @@ class BezierCurve {
     }
 
     this.dragEnabled = false;
+    this.noFill = true;
     this.initPoints();
   }
 
@@ -98,16 +99,7 @@ class BezierCurve {
   }
 
   draw(){
-    if (this.fillColor){
-      fill(this.fillColor);
-    } else {
-      noFill();
-    }
-    if (this.strokeColor) {
-      stroke(this.strokeColor);
-    } else {
-      stroke(255);
-    }
+    P5JsUtils.applyStyleSet(this);
     bezier(this.p1.x, this.p1.y,
            this.p2.x, this.p2.y,
            this.p3.x, this.p3.y,
@@ -120,13 +112,17 @@ class BezierCurve {
   }
 
   drawGuideLines(){
+    push();
     stroke(100, 200, 100);
     line(this.p1.x, this.p1.y, this.p2.x, this.p2.y);
     line(this.p4.x, this.p4.y, this.p3.x, this.p3.y);
+    pop();
   }
 
   drawDraggablePoints(){
+    push();
     this.points.forEach(p => this.drawPoint(p));
+    pop();
   }
 
   drawPoint(point){

--- a/p5js/common/shapes/circle.js
+++ b/p5js/common/shapes/circle.js
@@ -6,7 +6,6 @@ class Circle {
     this.dragEnabled = false;
     this.isDragged = false;
 
-    this.fillColor = undefined;
     this.dragPos = new Point(0, 0);
     this.dragPos.pos = this.pos; 
     this.dragSize = new Point(this.x + this.radius, this.y);
@@ -160,9 +159,7 @@ class Circle {
   }
 
   draw(){
-    if (this.fillColor){
-      fill(this.fillColor);
-    }
+    P5JsUtils.applyStyleSet(this);
     ellipseMode(CENTER);
     ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
 

--- a/p5js/common/shapes/line_segment.js
+++ b/p5js/common/shapes/line_segment.js
@@ -7,7 +7,6 @@ class LineSegment {
 
     this.dragEnabled = false;
     this.isDragged = true;
-    this.strokeColor = undefined;
   }
 
   dx() { return this.endX - this.startX; }
@@ -67,9 +66,7 @@ class LineSegment {
   }
 
   draw(){
-    if (this.strokeColor) {
-      stroke(this.strokeColor);
-    }
+    P5JsUtils.applyStyleSet(this);
     line(this.startX, this.startY, this.endX, this.endY);
   }
 

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -205,6 +205,7 @@ class Paisley {
   }
 
   draw(){
+    P5JsUtils.applyStyleSet(this);
     this.polybezier.draw();
 
     if (this.dragEnabled) {

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -31,6 +31,12 @@ class Paisley {
     this.points.push(this.radiusPt);
   }
 
+  _constructorCall(){
+    return `new Paisley(${this.x}, ${this.y}, `
+            + `${this.heading}, ${this.bulbRadius},`
+            + `${this.tail.x}, ${this.tail.y});`;
+  }
+
   get x() { return this.pos.x; }
   get y() { return this.pos.y; }
   get heading() { return this._heading; }

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -60,7 +60,10 @@ class Paisley {
   }
 
   _initPolyBezier() {
-    this.polybezier = new Polybezier();
+    if (this.polybezier == undefined){
+      this.polybezier = new Polybezier();
+    }
+    this.polybezier.clear();
     this.polybezier.append(BezierCurve.circularQuarterArc(this.x, this.y, this.bulbRadius, this.heading - HALF_PI));
     this.polybezier.append(BezierCurve.circularQuarterArc(this.x, this.y, this.bulbRadius, this.heading));
 

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -2,6 +2,7 @@ class Paisley {
   constructor(x, y, heading, bulbRadius) {
     this.pos = new Point(x, y);
     this.bulbRadius = bulbRadius;
+    this.radiusPt = new Point(0,0);
 
     this.leftShoulderPt = new Point(x, y);
     this.rightShoulderPt = new Point(x, y);
@@ -22,6 +23,7 @@ class Paisley {
     this.points.push(this.pos);
     this.points.push(this.tail);
     this.points.push(this.headingPt);
+    this.points.push(this.radiusPt);
   }
 
   get x() { return this.pos.x; }
@@ -39,6 +41,11 @@ class Paisley {
   _updateHeadingPt(){
     this.headingPt.x = this.x + this.headingVec.x * this.bulbRadius;
     this.headingPt.y = this.y + this.headingVec.y * this.bulbRadius;
+  }
+
+  _updateRadiusPt(){
+    this.radiusPt.x = this.leftShoulderPt.x;
+    this.radiusPt.y = this.leftShoulderPt.y;
   }
 
   _initPolyBezier() {
@@ -104,6 +111,7 @@ class Paisley {
     this.leftConstraint.set(step);
     this.leftConstraint.mult(leftMag);
     this.leftConstraint.add(this.leftShoulderPt.pos);
+    this._updateRadiusPt();
   }
 
   // This method tries to dynamically adjust the constraint points for the
@@ -162,6 +170,10 @@ class Paisley {
     } else if (this.pressedElement == this.headingPt){
       let newHeadingVec = createVector(this.headingPt.x - this.x,this.headingPt.y - this.y);
       this.heading = newHeadingVec.heading();
+      this._calcHelperPoints();
+    } else if (this.pressedElement == this.radiusPt){
+      this.bulbRadius = this.pos.distTo(this.radiusPt);
+      this._updateHeadingPt();
       this._calcHelperPoints();
     }
     this._initPolyBezier();

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -1,5 +1,5 @@
 class Paisley {
-  constructor(x, y, heading, bulbRadius) {
+  constructor(x, y, heading, bulbRadius, tailX, tailY) {
     this.pos = new Point(x, y);
     this.bulbRadius = bulbRadius;
     this.radiusPt = new Point(0,0);
@@ -15,7 +15,12 @@ class Paisley {
     this.heading = heading;
 
     this.draggable = false;
-    this._initDefaultTail();
+    if (tailX == undefined || tailY == undefined) {
+      this._initDefaultTail();
+    } else {
+      this.tail.x = tailX;
+      this.tail.y = tailY;
+    }
     this._calcHelperPoints();
 
     this._initPolyBezier();

--- a/p5js/common/shapes/point.js
+++ b/p5js/common/shapes/point.js
@@ -16,6 +16,10 @@ class Point {
     this.y = y;
   }
 
+  distTo(otherPoint){
+    return dist(this.x, this.y, otherPoint.x, otherPoint.y);
+  }
+
   move(x, y){
     this.x += x;
     this.y += y;

--- a/p5js/common/shapes/polybezier.js
+++ b/p5js/common/shapes/polybezier.js
@@ -119,6 +119,17 @@ class Polybezier {
   }
 
   draw(){
+    P5JsUtils.applyStyleSet(this);
     this.curves.forEach(c => c.draw());
+  }
+
+  // Unused
+  _drawEachEachCurve(){
+    beginShape();
+    vertex(this.curves[0].p1.x, this.curves[0].p1.y);
+    this.curves.forEach(bc => {
+      bezierVertex(bc.p2.x, bc.p2.y, bc.p3.x, bc.p3.y, bc.p4.x, bc.p4.y);
+    });
+    endShape();
   }
 }

--- a/p5js/common/shapes/polybezier.js
+++ b/p5js/common/shapes/polybezier.js
@@ -1,5 +1,13 @@
 class Polybezier {
   constructor(){
+    this._reset();
+  }
+
+  clear(){
+    this._reset()
+  }
+
+  _reset(){
     this.curves = [];
     this.closed = false;
   }

--- a/p5js/common/shapes/rectangle.js
+++ b/p5js/common/shapes/rectangle.js
@@ -111,7 +111,7 @@ class Rectangle extends Rect {
   }
 
   draw(){
-    fill(this.fillColor);
+    P5JsUtils.applyStyleSet(this);
     rect(this.x, this.y, this.width, this.height);
 
     if (this.dragEnabled) {

--- a/p5js/common/shapes/triangle.js
+++ b/p5js/common/shapes/triangle.js
@@ -7,7 +7,6 @@ class Triangle {
     this.dragEnabled = false;
     this.isDragged = false;
 
-    this.fillColor = undefined;
     this.points = [this.p1, this.p2, this.p3];
   }
 
@@ -36,9 +35,7 @@ class Triangle {
   }
 
   draw(){
-    if (this.fillColor){
-      fill(this.fillColor);
-    }
+    P5JsUtils.applyStyleSet(this);
     triangle(this.p1.x, this.p1.y,
              this.p2.x, this.p2.y,
              this.p3.x, this.p3.y);


### PR DESCRIPTION
Makes the approach of setting p5js options of `fill(...)` and `stroke(...)` a bit simpler; more consistent, and removes the behavior of setting a default option.

Note: This shouldn't conflict with the use of `push(); and pop();` to isolate changes; it just doesn't require it.