### PR TITLE
p5js/common - Fix mobile touch handling

### DIFF
--- a/p5js/common/examples/draggable/index.md
+++ b/p5js/common/examples/draggable/index.md
@@ -7,7 +7,7 @@ viewport_noscale: true
 excerpt: Implements draggable shapes for use in other sketches.
 
 js_scripts:
-- https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js
+- /sketchbook/vendor/p5.js/0.7.2/p5.js
 - /sketchbook/p5js/common/p5js_settings.js
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js

--- a/p5js/common/examples/geometry-circle-line/index.md
+++ b/p5js/common/examples/geometry-circle-line/index.md
@@ -7,7 +7,7 @@ viewport_noscale: true
 excerpt: Demonstration of the algorithm to find intersection of a line with a circle.
 
 js_scripts:
-- https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js
+- /sketchbook/vendor/p5.js/0.7.2/p5.js
 - /sketchbook/p5js/common/p5js_settings.js
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js


### PR DESCRIPTION
Despite documentation, it doesn't appear that mouseDragged() is getting called in latest version of p5.js (v1.11.2) without touchMoved() defined 

And don't want to add handleTouch for geometry shapes ... yet

So for now, reverting to older version of p5.js where touch events work as expected.