### PR TITLE
p5js/common/voronoi - Add optimization option to only redraw cells marked as needing to be redrawn

### DIFF
--- a/p5js/common/examples/voronoi-2/index.md
+++ b/p5js/common/examples/voronoi-2/index.md
@@ -4,7 +4,7 @@ title:  "p5.js - Common Examples - Voronoi 2"
 categories: p5js
 modal: true
 viewport_noscale: true
-excerpt: Demonstrates the modified p5.voronoi (for multiple diagrams in one sketch)
+excerpt: Demonstrates the modified p5.voronoi to have multiple interactive diagrams in one sketch.
 
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js

--- a/p5js/common/examples/voronoi-3/README.md
+++ b/p5js/common/examples/voronoi-3/README.md
@@ -1,0 +1,37 @@
+
+## Overview
+
+This is a [p5.js][p5js-home] sketch to explore some optimizations in rendering Voronoi diagrams.
+
+Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some perfromance profiling and fine tuning.
+
+## Controls
+
+Mouse
+* `hover` Moving the mouse around will highlight the cell under the mouse cursor;
+
+Touch
+* `press` Touching anywhere (and pressing and moving around) will highlight the cell under touch point.
+
+# References:
+* [p5.voronoi.js][p5_voronoi] - The main p5.js extension that enables drawing of of a Voronoi diagram.
+* [gorhill-voronoi][gorhill-voronoi] - The primary underlying implementation of the Voronoi algorithm in Javascript.
+* [Chrome Performance Tools][chrome-perf-tools]
+
+
+# Links: 
+
+* [Live View][live-view]
+* [Source on Github][source-code]
+
+# Screenshot:
+
+![screenshot][screenshot-01]
+
+[p5js-home]: https://p5js.org/
+[source-code]: https://github.com/brianhonohan/sketchbook/tree/master/p5js/common/examples/voronoi-3/
+[live-view]: https://brianhonohan.com/sketchbook/p5js/common/examples/voronoi-3/
+[screenshot-01]: ./screenshot-01.png
+[p5.voronoi.js]: https://github.com/Dozed12/p5.voronoi
+[gorhill-voronoi]: https://github.com/gorhill/Javascript-Voronoi
+[chrome-perf-tools]: https://developer.chrome.com/docs/devtools/performance

--- a/p5js/common/examples/voronoi-3/app.js
+++ b/p5js/common/examples/voronoi-3/app.js
@@ -14,9 +14,9 @@ let lastTouch;
 
 var gui;
 var systemParams = {
-  sitesPerDiagram: 200,
+  sitesPerDiagram: 2000,
   highlightNeighbors: true,
-  drawFourDiagrams: true,
+  drawFourDiagrams: false,
 }
 
 function setup() {
@@ -24,7 +24,7 @@ function setup() {
   createCanvas(800, 600);
 
   gui = P5JsSettings.addDatGui({autoPlace: false});
-  guiSitesPerDiagrams = gui.add(systemParams, "sitesPerDiagram").min(1).max(5000).step(50);
+  guiSitesPerDiagrams = gui.add(systemParams, "sitesPerDiagram").min(1).max(10000).step(50);
   gui.add(systemParams, "highlightNeighbors");
   guiDrawFourDiagrams = gui.add(systemParams, "drawFourDiagrams");
   addGuiListeners();
@@ -73,7 +73,7 @@ function draw(){
 
   voronoiSiteStroke(color(180,50, 50));
   fill(50, 180, 50);
-  drawVoronoi(voronoiOne, 0, 0);
+  drawVoronoi(voronoiOne, 0, 0, { redrawAll: false });
   
   if (systemParams.drawFourDiagrams){
     voronoiSiteStroke(color(180,100, 180));
@@ -138,11 +138,13 @@ function drawHighlightedCell(){
   stroke(200);
   translate(highlightedOffset.x, highlightedOffset.y);
   drawVoronoiCell(highlightedCell, 0, 0, VOR_CELLDRAW_RELATIVE);
+  highlightedCell.needsRedraw = true;
 
   if (systemParams.highlightNeighbors){
     for(let i = 0; i < highlightedCellNeighbors.length; i++){
       fill(180, 110, 100);
       drawVoronoiCell(highlightedCellNeighbors[i], 0, 0, VOR_CELLDRAW_RELATIVE, true);
+      highlightedCellNeighbors[i].needsRedraw = true;
     }
   }
   pop();

--- a/p5js/common/examples/voronoi-3/app.js
+++ b/p5js/common/examples/voronoi-3/app.js
@@ -1,0 +1,176 @@
+let voronoiOne;
+let voronoiTwo;
+let voronoiThree;
+let voronoiFour;
+
+let halfWidth;
+let halfHeight;
+let bbox;
+let highlightedCell;
+let highlightedOffset;
+let highlightedCellNeighbors;
+let lastTouch;
+
+
+var gui;
+var systemParams = {
+  sitesPerDiagram: 200,
+  highlightNeighbors: true,
+  drawFourDiagrams: true,
+}
+
+function setup() {
+  // createCanvas(windowWidth, windowHeight-35);
+  createCanvas(800, 600);
+
+  gui = P5JsSettings.addDatGui({autoPlace: false});
+  guiSitesPerDiagrams = gui.add(systemParams, "sitesPerDiagram").min(1).max(5000).step(50);
+  gui.add(systemParams, "highlightNeighbors");
+  guiDrawFourDiagrams = gui.add(systemParams, "drawFourDiagrams");
+  addGuiListeners();
+
+  generatePointsForDiagrams();
+}
+
+function generatePointsForDiagrams(){
+  if (systemParams.drawFourDiagrams){
+    halfWidth = 0.5 * width;
+    halfHeight = 0.5 * height;
+  } else {
+    halfWidth = width;
+    halfHeight = height;  
+  }
+  bbox = {xl: 0, xr: halfWidth, yt: 0, yb: halfHeight}; // xl is x-left, xr is x-right, yt is y-top, and yb is y-bottom
+
+  sites = randomPointsWithin(systemParams.sitesPerDiagram, bbox);
+  voronoiOne = createVoronoi(sites, bbox);
+  
+  if (systemParams.drawFourDiagrams){
+    sites = randomPointsWithin(systemParams.sitesPerDiagram, bbox);
+    voronoiTwo = createVoronoi(sites, bbox);
+
+    sites = randomPointsWithin(systemParams.sitesPerDiagram, bbox);
+    voronoiThree = createVoronoi(sites, bbox);
+
+    sites = randomPointsWithin(systemParams.sitesPerDiagram, bbox);
+    voronoiFour = createVoronoi(sites, bbox);
+  }
+}
+
+function addGuiListeners(){
+  guiSitesPerDiagrams.onFinishChange(function(value) {
+    generatePointsForDiagrams();
+  });
+  guiDrawFourDiagrams.onFinishChange(function(value) {
+    generatePointsForDiagrams();
+  });
+}
+
+function draw(){
+  voronoiSiteStrokeWeight(2);
+  stroke(50);
+  strokeWeight(0.5)
+
+  voronoiSiteStroke(color(180,50, 50));
+  fill(50, 180, 50);
+  drawVoronoi(voronoiOne, 0, 0);
+  
+  if (systemParams.drawFourDiagrams){
+    voronoiSiteStroke(color(180,100, 180));
+    fill(180, 180, 50);
+    drawVoronoi(voronoiTwo, halfWidth, 0);
+    
+    voronoiSiteStroke(color(180,100, 50));
+    fill(50, 180, 180);
+    drawVoronoi(voronoiThree, 0, halfHeight);
+
+    voronoiSiteStroke(color(180,100, 50));
+    fill(50, 50, 180);
+    drawVoronoi(voronoiFour, halfWidth, halfHeight);
+  }
+  
+  drawHighlightedCell();
+}
+
+function mouseMoved(){
+  highlightUnderMouse();
+}
+
+function touchMoved(){
+  lastTouch = touches[0];
+  highlightUnderMouse()
+}
+
+function highlightUnderMouse(){
+  if (lastTouch){
+    updatedHighlightCell(lastTouch.x, lastTouch.y);
+  } else {
+    updatedHighlightCell(mouseX, mouseY);
+  }
+}
+
+function updatedHighlightCell(x, y){
+  diagram = diagramForXY(x, y);
+  if (diagram == undefined){
+    return;
+  }
+  cell = diagram.getCellAtXY(x % halfWidth, y % halfHeight);
+  if (cell == undefined){
+    return;
+  }
+  if (cell == highlightedCell){
+    return;
+  }
+  highlightedOffset = {x: Math.floor(x/halfWidth) * halfWidth, y: Math.floor(y/halfHeight) * halfHeight};
+  highlightedCell = cell;
+  
+  if (systemParams.highlightNeighbors){
+    highlightedCellNeighbors = diagram.neighborsOfCell(cell);
+  }
+}
+
+function drawHighlightedCell(){
+  if (highlightedCell == undefined){
+    return;
+  }
+  push()
+  fill(180, 50, 50);
+  stroke(200);
+  translate(highlightedOffset.x, highlightedOffset.y);
+  drawVoronoiCell(highlightedCell, 0, 0, VOR_CELLDRAW_RELATIVE);
+
+  if (systemParams.highlightNeighbors){
+    for(let i = 0; i < highlightedCellNeighbors.length; i++){
+      fill(180, 110, 100);
+      drawVoronoiCell(highlightedCellNeighbors[i], 0, 0, VOR_CELLDRAW_RELATIVE, true);
+    }
+  }
+  pop();
+}
+
+function diagramForXY(x, y){
+  if (x < halfWidth && y < halfHeight){
+    return voronoiOne;
+  } else if (x >= halfWidth && y < halfHeight){
+    return voronoiTwo;
+  } else if (x < halfWidth && y >= halfHeight){
+    return voronoiThree;
+  } else {
+    return voronoiFour;
+  }
+}
+
+function randomPointsWithin(number, bbox){
+  return Array(number).fill().map(() => ({x: random(bbox.xl, bbox.xr), y: random(bbox.yt, bbox.yb)}));
+}
+
+function keyTyped(){
+  switch(key) {
+    case 'p':
+      saveCanvas(canvas, 'screenshot', 'png');
+      break;
+    case '0':
+      P5JsUtils.toggleLoop();
+      break;
+  }
+}

--- a/p5js/common/examples/voronoi-3/index.md
+++ b/p5js/common/examples/voronoi-3/index.md
@@ -1,0 +1,25 @@
+---
+layout: minimal
+title:  "p5.js - Common Examples - Voronoi 3"
+categories: p5js
+modal: true
+viewport_noscale: true
+excerpt: Explores some optimizations in regards to Voronoi diagrams.
+
+js_scripts:
+- https://cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js
+- https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js
+- /sketchbook/vendor/dat.gui/0.7.3/dat.gui.js
+- /sketchbook/p5js/common/p5js_settings.js
+- /sketchbook/p5js/common/p5js_utils.js
+- /sketchbook/js/util_functions.js
+- /sketchbook/js/options_set.js
+- /sketchbook/vendor/gorhill/rhill-voronoi-core.js
+- /sketchbook/js/models/voronoi_ext.js
+- /sketchbook/p5js/common/p5js_voronoi.js
+- app.js
+
+---
+
+{% include_relative README.md %}
+

--- a/p5js/common/examples/voronoi-3/local_dev.html
+++ b/p5js/common/examples/voronoi-3/local_dev.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>P5.JS - Examples - Voronoi 3</title>
+    <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.1/inobounce.js" charset="utf-8"></script>
+    <script src="/sketchbook/vendor/dat.gui/0.7.3/dat.gui.js"></script>
+    <script src="/sketchbook/vendor/p5.js/1.11.2/p5.min.js" charset="utf-8"></script>
+    <script src="/sketchbook/p5js/common/p5js_settings.js" charset="utf-8"></script>
+    <script src="/sketchbook/p5js/common/p5js_utils.js" charset="utf-8"></script>
+    <script src="/sketchbook/js/util_functions.js" charset="utf-8"></script>
+    <script src="/sketchbook/js/options_set.js" charset="utf-8"></script>
+    <script src="/sketchbook/vendor/gorhill/rhill-voronoi-core.js"></script>
+
+    <script src="/sketchbook/js/models/voronoi_ext.js"></script>
+    <script src="/sketchbook/p5js/common/p5js_voronoi.js"></script>
+    
+    <script src="app.js" charset="utf-8"></script>
+<style>
+body {
+  margin: 0;
+  font-family: Sans-Serif;
+}
+</style>
+</head>
+<body>
+</body>
+</html>

--- a/p5js/common/examples/voronoi/index.md
+++ b/p5js/common/examples/voronoi/index.md
@@ -3,7 +3,7 @@ layout: minimal
 title:  "p5.js - Common Examples - Voronoi"
 categories: p5js
 modal: true
-excerpt: Demonstrates the modified p5.voronoi (for multiple diagrams in one sketch)
+excerpt: Demonstrates preliminary modified p5.voronoi, working towards multiple interactive diagrams in one sketch.
 
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js

--- a/p5js/common/p5js_voronoi.js
+++ b/p5js/common/p5js_voronoi.js
@@ -104,8 +104,10 @@ p5.prototype.createVoronoi = function(sites, boundingBox) {
   return voronoi.compute(sites, boundingBox);
 }
 
-p5.prototype.drawVoronoi = function(diagram, x, y) {
+p5.prototype.drawVoronoi = function(diagram, x, y, options = {}) {
   var cells = diagram.cells;
+  const drawOptions = { redrawAll: true }
+  for (var attrname in options) { drawOptions[attrname] = options[attrname]; }
 
   push();
   translate(x, y);
@@ -114,7 +116,12 @@ p5.prototype.drawVoronoi = function(diagram, x, y) {
   for (var i = 0; i < cells.length; i++) {
     // This draws all edges twice, but it's not a big deal; might overweight the line
     // this is only of benefit if we want to fill the cells with diff colors
-    drawVoronoiCell(cells[i], 0, 0, VOR_CELLDRAW_RELATIVE);
+    if (drawOptions.redrawAll) {
+      drawVoronoiCell(cells[i], 0, 0, VOR_CELLDRAW_RELATIVE);
+    } else if (cells[i].needsRedraw == undefined || cells[i].needsRedraw) {
+      drawVoronoiCell(cells[i], 0, 0, VOR_CELLDRAW_RELATIVE);
+    }
+    cells[i].needsRedraw = false;
   }
 
   //Render Site


### PR DESCRIPTION
This adds a mode to too only draw if the cell needs to be draw

And allows external context to set that

For example, here, when after drawing highlighted cells, we mark them for redraw in the next frame. They may still be highlighted, but will be redrawn anyway (this is a slight inefficiency, but overall this speeds up the draw cycle considerably).

This allowed the voronoi diagram to have upwards of 10000 cells without frame drops on highlight. 

Up next: Use quadtree to find highlighted cell.

----

### Pre-Optimization

![Pre-Optimization--Screenshot 2025-01-07 225833](https://github.com/user-attachments/assets/2620bb6f-2dce-46f5-9b85-b3891f96bf66)

### Post-Optimization
![Post-Optimization--Screenshot 2025-01-07 225853](https://github.com/user-attachments/assets/7a6d0c38-3889-4a08-8d24-d4619de390f9)
