### PR TITLE
p5js/ecosystem - Add dat.gui controls

### DIFF
--- a/p5js/common/examples/voronoi-2/README.md
+++ b/p5js/common/examples/voronoi-2/README.md
@@ -3,7 +3,7 @@
 
 This is a [p5.js][p5js-home] sketch to demonstrate the a revised version of `p5.voronoi` library which enables having multiple diagrams in parallel with each other; and allows for the reliance / utilization of p5.js styling control for all but the sites.
 
-Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some perfromance profiling and fine tuning, but will leave some of those optimizations to the next iteration of this sketch.
+Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some performance profiling and fine tuning, but will leave some of those optimizations to the next iteration of this sketch.
 
 ## Controls
 

--- a/p5js/common/examples/voronoi-3/README.md
+++ b/p5js/common/examples/voronoi-3/README.md
@@ -3,7 +3,7 @@
 
 This is a [p5.js][p5js-home] sketch to explore some optimizations in rendering Voronoi diagrams.
 
-Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some perfromance profiling and fine tuning.
+Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some performance profiling and fine tuning.
 
 ## Controls
 

--- a/p5js/common/examples/voronoi-4/README.md
+++ b/p5js/common/examples/voronoi-4/README.md
@@ -9,7 +9,7 @@ And further compare the developer experience working wiht the two libraries.
 
 In short, the two libraries are comparable in performance on rendering as it relates to adpating to the p5.js drawing context. I did not test/benchmark delaunay/voronoi computation. And generally found the gorhill-implementation more readily available for extension for my uses (at this time).
 
-Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some perfromance profiling and fine tuning.
+Of note, used [Chrome Performance Tools][chrome-perf-tools] to do some performance profiling and fine tuning.
 
 ## Controls
 

--- a/p5js/common/p5js_settings.js
+++ b/p5js/common/p5js_settings.js
@@ -37,6 +37,22 @@ class P5JsSettings {
         }
       });
     }
+    if (datGuiParams.bindOptions === true) {
+      const seedListener = datGui.add(this.optionsSet.settings, "seed", 1, Number.MAX_SAFE_INTEGER);
+      const noiseOctavesListener = datGui.add(this.optionsSet.settings, "noise_octaves", 1, 16);
+      const noiseFallOffListener = datGui.add(this.optionsSet.settings, "noise_falloff", 0.01, 1, 0.01);
+
+      const globalSettings = this;
+      const handleDatGui = function(callback){
+        globalSettings.applySettings();
+        if (callback !== undefined){
+          callback();
+        }
+      }
+      seedListener.onFinishChange(() => handleDatGui(datGuiParams.callback));
+      noiseOctavesListener.onFinishChange(() => handleDatGui(datGuiParams.callback));
+      noiseFallOffListener.onFinishChange(() => handleDatGui(datGuiParams.callback));
+    }
     return datGui;
   }
 

--- a/p5js/ecosystem/app.js
+++ b/p5js/ecosystem/app.js
@@ -8,8 +8,15 @@ function setup() {
   let rect = new Rect(0, 0, width, height);
   ecosystem = new Ecosystem(rect);
 
+  gui = P5JsSettings.addDatGui({autoPlace: false, 
+    bindOptions: true, callback: regenerateSystem});
+
   logSettings();
   frameRate(1);
+}
+
+function regenerateSystem(){
+  ecosystem.generate();
 }
 
 function draw() {

--- a/p5js/ecosystem/app.js
+++ b/p5js/ecosystem/app.js
@@ -1,5 +1,6 @@
 let seed;
 let ecosystem;
+let genericGuiListeners = [];
 
 function setup() {
   createCanvas(windowWidth, windowHeight-35);
@@ -8,11 +9,19 @@ function setup() {
   let rect = new Rect(0, 0, width, height);
   ecosystem = new Ecosystem(rect);
 
-  gui = P5JsSettings.addDatGui({autoPlace: false, 
-    bindOptions: true, callback: regenerateSystem});
-
+  gui = P5JsSettings.addDatGui({autoPlace: false, bindOptions: true, callback: regenerateSystem});
+  genericGuiListeners.push(gui.add(ecosystem.settings, "cellWidth", 1, 100, 1));
+  genericGuiListeners.push(gui.add(ecosystem.settings, "scale", 0.0001, 0.2, 0.0001));
+  genericGuiListeners.push(gui.add(ecosystem.settings, "percentWater", 0, 1, 0.01));
+  genericGuiListeners.push(gui.add(ecosystem.settings, "erosionRate", 0, 1, 0.0001));
+  addGuiListeners();
+  
   logSettings();
   frameRate(1);
+}
+
+function addGuiListeners(){
+  genericGuiListeners.forEach(l => l.onFinishChange( () => regenerateSystem() ));
 }
 
 function regenerateSystem(){

--- a/p5js/ecosystem/classes/ecosystem.js
+++ b/p5js/ecosystem/classes/ecosystem.js
@@ -3,7 +3,10 @@ class Ecosystem {
     this.sizeAndPosition = p_xSizeAndPos;
     this.optionsSet = new OptionsSet(this.optionsMetadata());
     this.settings = this.optionsSet.settings;
+    this.generate();
+  }
 
+  generate(){
     this.determineMagicWaterPercentageFactor();
     this.grid = new CellGrid(this.sizeAndPosition, this, this.settings.cellWidth);
     this.grid.initCells();

--- a/p5js/ecosystem/index.md
+++ b/p5js/ecosystem/index.md
@@ -8,7 +8,8 @@ excerpt: Randomly generated terrain, with the intention of creating an environme
 
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js
-- https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.23/p5.js
+- /sketchbook/vendor/p5.js/1.11.2/p5.min.js
+- /sketchbook/vendor/dat.gui/0.7.7/dat.gui.js
 - /sketchbook/p5js/common/p5js_settings.js
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js

--- a/p5js/ecosystem/local_dev.html
+++ b/p5js/ecosystem/local_dev.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js" charset="utf-8"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.23/p5.js" charset="utf-8"></script>
+    <script src="/sketchbook/vendor/p5.js/1.11.2/p5.min.js"></script>
+    <script src="/sketchbook/vendor/dat.gui/0.7.7/dat.gui.js"></script>
     <script src="/sketchbook/p5js/common/p5js_settings.js"></script>
     <script src="/sketchbook/p5js/common/p5js_utils.js"></script>
     <script src="/sketchbook/js/util_functions.js"></script>


### PR DESCRIPTION
This enhances: https://brianhonohan.com/sketchbook/p5js/ecosystem/
- to add dat.gui (https://github.com/dataarts/dat.gui) controls of parameters

Hopefully this will allow for easier testing of different input parameters to get the right scale / coarseness for future sketches.

-----


This also includes a general enhancement to the `P5jsSettings` object to have it expose the seed and noise when adding the dat.gui config.