### PR TITLE
MINOR - Add excerpts to posts to prevent layout bugs.

### DIFF
--- a/_posts/2017-11-04-p5-js-procedural-generation-of-terrain-with-perlin-noise.markdown
+++ b/_posts/2017-11-04-p5-js-procedural-generation-of-terrain-with-perlin-noise.markdown
@@ -4,6 +4,7 @@ title:  "P5.JS - Procedural Generation of Terrain"
 date:   2017-11-04 13:31:15 -0400
 categories: p5js
 thumbnail: /sketchbook/p5js/ecosystem/screenshot-01.png
+excerpt: Using Perlin noise to generate terrain, with approximate controls for percent of water and graduated color maps for elevation and water depth.
 
 ---
 

--- a/_posts/coding-challenges/2018-10-06-coding-challenge-6-mitosis.md
+++ b/_posts/coding-challenges/2018-10-06-coding-challenge-6-mitosis.md
@@ -3,7 +3,7 @@ title:  "Coding Challenge #6 - Mitosis"
 date:   2018-10-06 8:00:00 -0400
 categories: [p5js, coding-challenges]
 thumbnail: /sketchbook/p5js/coding-challenges/mitosis/screenshot-01.png
-
+excerpt: Preliminary sketch of cellular mitosis, splitting a vector shape into two while modeling the phases of cellular division.
 ---
 
 This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-train] [Coding Challenge #6][ct-challenge-6] on creating a simulation of [Mitosis][wikipedia-mitosis]

--- a/_posts/coding-challenges/2018-10-07-coding-challenge-7-solar-system.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-7-solar-system.md
@@ -3,6 +3,7 @@ title:  "Coding Challenge #7 - Solar System"
 date:   2018-10-07 14:00:00 -0400
 categories: [p5js, coding-challenges]
 thumbnail: /sketchbook/p5js/coding-challenges/solar-system/screenshot-01.png
+excerpt: Basic implementation of n-body problem modeling the force of gravity in a simple solar system model.
 ---
 
 This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-train] [Coding Challenge #7][ct-challenge-7] of creating a Solar System.

--- a/_posts/coding-challenges/2018-10-07-coding-challenge-8-solar-system-3d.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-8-solar-system-3d.md
@@ -3,6 +3,7 @@ title:  "Coding Challenge #8 - Solar System 3D"
 date:   2018-10-07 16:00:00 -0400
 categories: [p5js, coding-challenges]
 thumbnail: /sketchbook/p5js/coding-challenges/solar-system-3d/screenshot-01.png
+excerpt: Building on the 2D-sketch, this makes use of 3D-vectors to model the Solar System. Highlights the value of refactoring away 2D concepts to make it ready for 3D support.
 ---
 
 This is a [p5.js][p5js-home] sketch inspired by the [Coding Train's][coding-train] [Coding Challenge #8][ct-challenge-8] on creating a Solar System modeled in 3D.

--- a/_posts/coding-challenges/2018-10-07-coding-challenge-9-solar-system-3d-texturized.md
+++ b/_posts/coding-challenges/2018-10-07-coding-challenge-9-solar-system-3d-texturized.md
@@ -3,6 +3,7 @@ title:  "Coding Challenge #9 - Add textures to 3D Solar System"
 date:   2018-10-07 20:00:00 -0400
 categories: [p5js, coding-challenges]
 thumbnail: /sketchbook/p5js/coding-challenges/solar-system-3d-texturized/screenshot-01.png
+excerpt: Explores use of p5.js' texture() option to wrap the planets in images (textures).
 
 ---
 


### PR DESCRIPTION
Without these, the template would break, as Jekyll would try to auto-generate an excerpt from the content, and given the nature of the JS / Images, this would break the layout.

Ramification of this was a simple line of text preceding the header, not a big deal, but not great. Interestingly, my local jekyll would break-more, the index page would also break the excerpts whereas Github pages didn't seem to fall victim to the bug in that context

Alternate approach to consider in the future is to switch to: {{ post.content | strip_html | truncatewords: 50 }}

In place of {{ post.excerpt }}
From: https://stackoverflow.com/a/23504519

(Though that presumes the first 50 words are a good summation of the post).