### PR TITLE
p5js/cc/marching-squares-2 - Add pixel renderer at high resolution (low cell width)

### DIFF
--- a/p5js/coding-challenges/marching-squares-2/app.js
+++ b/p5js/coding-challenges/marching-squares-2/app.js
@@ -32,7 +32,7 @@ function setup() {
   // P5JsSettings.addObject(gui, system, regenerateSystem);
 
   // Option 3: method chaining
-  gui.add(system.settings, "cellWidth", 1, 12, 2).onChange(reinitSystem);
+  gui.add(system.settings, "cellWidth", 2, 40, 2).onChange(reinitSystem);
   gui.add(system.settings, "scale", 0.01, 0.5, 0.001).onChange(regenerateSystem);
   gui.add(system.settings, "xOffset", -10000, 10000, 1).onChange(regenerateSystem);
   gui.add(system.settings, "yOffset", -10000, 10000, 1).onChange(regenerateSystem);


### PR DESCRIPTION
When the cell width gets real small, it seems sensible to switch to pixel rendering

Performance testing bears this out <= 4 pixels per cell (rectangle) which is actually only rendered as a 2px by 2px square (because I'm applying a 25% margin)

Also, for simplicity, restrict the cellWidth to even numbers and apply rounding/flooring of pixel values.

---

### Performance testing:

#### Cell Width 4 pixels

*As Rect* 🐢 
~28.78 ms/frame
![900x900-cw4_via-rect--Screenshot 2025-01-26 220516](https://github.com/user-attachments/assets/0cf048e1-326e-4227-9e90-4b55c5a97499)

*Via Pixels* 🐇 
14.91 ms/frame
![900x900_cw4_via-pixels-Screenshot 2025-01-26 220642](https://github.com/user-attachments/assets/f89f0252-c3c7-4ed0-9a72-634f9b934515)


### Cell Width 10 pixels

*As Rect* 🐇 
3.47 ms/frame
(substantially fewer cells)
![900x900_cw10__viaRect-Screenshot 2025-01-26 220759](https://github.com/user-attachments/assets/9d4ecb42-f34d-4b0e-88dc-ee811456304d)

*Via Pixels* 🐢 
6.44 ms/frame
![900x900_cw10__viaPixels--SLOWER-Screenshot 2025-01-26 220914](https://github.com/user-attachments/assets/ff2c3473-23b9-4a76-8e32-691a984ac947)


