### PR TITLE
p5js/cc/marching squares-2 Explore some optimizations

### DIFF
--- a/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
+++ b/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
@@ -10,7 +10,7 @@ class CellViewer {
     this.renderMarginX = Math.floor(0.25 * cellWidth);
     this.renderMarginY = Math.floor(0.25 * cellHeight);
 
-    this.isPixelRenderer = (cellWidth <= 4);
+    this.isPixelRenderer = (cellWidth <= 6);
     this.rectRenderFunction = (this.isPixelRenderer) ? this._fillCellsViaPixels : this._fillCellsViaRect;
 
     this.fillColor = color(50, 200, 200);

--- a/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
+++ b/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
@@ -27,6 +27,13 @@ class CellViewer {
     this.mgYOffsets[2] = cellHeight + this.halfCellHeight;
     this.mgYOffsets[3] = cellHeight;
 
+    // class variables to avoid garbage collection
+    // should not be used outside of this._drawInterpolatedLines()
+    this.pt0 = createVector();
+    this.pt1 = createVector();
+    this.pt2 = createVector();
+    this.pt3 = createVector();
+
     this.precomputeVerticesForCase();
   }
 
@@ -148,10 +155,6 @@ class CellViewer {
     let valueBelow;
     let valueDownToRight;
 
-    let pt0 = createVector();
-    let pt1 = createVector();
-    let pt2 = createVector();
-    let pt3 = createVector();
     let interpAmt;
 
     let cellX;
@@ -181,65 +184,65 @@ class CellViewer {
 
       // FROM https://editor.p5js.org/codingtrain/sketches/18cjVoAX1
       interpAmt = (1 - cellValue) / (valueToRight - cellValue);
-      pt0.x = lerp(cellX, cellX + this.cellWidth, interpAmt);
-      pt0.y = cellY;
+      this.pt0.x = lerp(cellX, cellX + this.cellWidth, interpAmt);
+      this.pt0.y = cellY;
 
       interpAmt = (1 - valueToRight) / (valueDownToRight - valueToRight);
-      pt1.x = cellX + this.cellWidth;
-      pt1.y = lerp(cellY, cellY + this.cellWidth, interpAmt);
+      this.pt1.x = cellX + this.cellWidth;
+      this.pt1.y = lerp(cellY, cellY + this.cellWidth, interpAmt);
 
       interpAmt = (1 - valueBelow) / (valueDownToRight - valueBelow);
-      pt2.x = lerp(cellX, cellX + this.cellWidth, interpAmt);
-      pt2.y = cellY + this.cellWidth;
+      this.pt2.x = lerp(cellX, cellX + this.cellWidth, interpAmt);
+      this.pt2.y = cellY + this.cellWidth;
 
       interpAmt = (1 - cellValue) / (valueBelow - cellValue);
-      pt3.x = cellX;
-      pt3.y = lerp(cellY, cellY + this.cellWidth, interpAmt);
+      this.pt3.x = cellX;
+      this.pt3.y = lerp(cellY, cellY + this.cellWidth, interpAmt);
 
       switch (cells[i].mgCase) {
         case 1:
-          this.drawLine(pt0, pt3);
+          this.drawLine(this.pt0, this.pt3);
           break;
         case 2:
-          this.drawLine(pt0, pt1);
+          this.drawLine(this.pt0, this.pt1);
           break;
         case 3:
-          this.drawLine(pt3, pt1);
+          this.drawLine(this.pt3, this.pt1);
           break;
         case 4:
-          this.drawLine(pt1, pt2);
+          this.drawLine(this.pt1, this.pt2);
           break;
         case 5:
-          this.drawLine(pt0, pt1);
-          this.drawLine(pt2, pt3);
+          this.drawLine(this.pt0, this.pt1);
+          this.drawLine(this.pt2, this.pt3);
           break;
         case 6:
-          this.drawLine(pt0, pt2);
+          this.drawLine(this.pt0, this.pt2);
           break;
         case 7:
-          this.drawLine(pt3, pt2);
+          this.drawLine(this.pt3, this.pt2);
           break;
         case 8:
-          this.drawLine(pt3, pt2);
+          this.drawLine(this.pt3, this.pt2);
           break;
         case 9:
-          this.drawLine(pt0, pt2);
+          this.drawLine(this.pt0, this.pt2);
           break;
         case 10:
-          this.drawLine(pt0, pt3);
-          this.drawLine(pt1, pt2);
+          this.drawLine(this.pt0, this.pt3);
+          this.drawLine(this.pt1, this.pt2);
           break;
         case 11:
-          this.drawLine(pt1, pt2);
+          this.drawLine(this.pt1, this.pt2);
           break;
         case 12:
-          this.drawLine(pt3, pt1);
+          this.drawLine(this.pt3, this.pt1);
           break;
         case 13:
-          this.drawLine(pt0, pt1);
+          this.drawLine(this.pt0, this.pt1);
           break;
         case 14:
-          this.drawLine(pt0, pt3);
+          this.drawLine(this.pt0, this.pt3);
           break;
       }
     }

--- a/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
+++ b/p5js/coding-challenges/marching-squares-2/classes/cell_viewer.js
@@ -35,6 +35,7 @@ class CellViewer {
     this.pt3 = createVector();
 
     this.precomputeVerticesForCase();
+    this.precomputePointsForCase();
   }
 
   renderCell(tmpCell, tmpX, tmpY, cellWidth, cellHeight){
@@ -199,52 +200,7 @@ class CellViewer {
       this.pt3.x = cellX;
       this.pt3.y = lerp(cellY, cellY + this.cellWidth, interpAmt);
 
-      switch (cells[i].mgCase) {
-        case 1:
-          this.drawLine(this.pt0, this.pt3);
-          break;
-        case 2:
-          this.drawLine(this.pt0, this.pt1);
-          break;
-        case 3:
-          this.drawLine(this.pt3, this.pt1);
-          break;
-        case 4:
-          this.drawLine(this.pt1, this.pt2);
-          break;
-        case 5:
-          this.drawLine(this.pt0, this.pt1);
-          this.drawLine(this.pt2, this.pt3);
-          break;
-        case 6:
-          this.drawLine(this.pt0, this.pt2);
-          break;
-        case 7:
-          this.drawLine(this.pt3, this.pt2);
-          break;
-        case 8:
-          this.drawLine(this.pt3, this.pt2);
-          break;
-        case 9:
-          this.drawLine(this.pt0, this.pt2);
-          break;
-        case 10:
-          this.drawLine(this.pt0, this.pt3);
-          this.drawLine(this.pt1, this.pt2);
-          break;
-        case 11:
-          this.drawLine(this.pt1, this.pt2);
-          break;
-        case 12:
-          this.drawLine(this.pt3, this.pt1);
-          break;
-        case 13:
-          this.drawLine(this.pt0, this.pt1);
-          break;
-        case 14:
-          this.drawLine(this.pt0, this.pt3);
-          break;
-      }
+      this._renderInterpolatedLines(cells[i]);
     }
   }
 
@@ -293,6 +249,34 @@ class CellViewer {
     this.verticesForCase[8] = [3, 2];
   }
 
+  precomputePointsForCase(){
+    this.pointsForCase = [];
+
+    this.pointsForCase[0] = [];
+    this.pointsForCase[15] = [];
+
+    this.pointsForCase[1] = [this.pt0, this.pt3];
+    this.pointsForCase[14] = [this.pt0, this.pt3];
+    
+    this.pointsForCase[2] = [this.pt0, this.pt1];
+    this.pointsForCase[13] = [this.pt0, this.pt1];
+    
+    this.pointsForCase[3] = [this.pt3, this.pt1];
+    this.pointsForCase[12] = [this.pt3, this.pt1];
+
+    this.pointsForCase[4] = [this.pt1, this.pt2];
+    this.pointsForCase[11] = [this.pt1, this.pt2];
+
+    this.pointsForCase[5] = [[this.pt0, this.pt1], [this.pt2, this.pt3]];
+    this.pointsForCase[10] = [[this.pt0, this.pt3], [this.pt1, this.pt2]];
+
+    this.pointsForCase[6] = [this.pt0, this.pt2];
+    this.pointsForCase[9] = [this.pt0, this.pt2];
+
+    this.pointsForCase[7] = [this.pt3, this.pt2];
+    this.pointsForCase[8] = [this.pt3, this.pt2];
+  }
+
   
   renderMarchingGridTile(tmpCell, x, y){
     if (tmpCell.mgCase == undefined) { return; }
@@ -306,6 +290,21 @@ class CellViewer {
       return;
     }
     this._drawFromTo(x, y, this.verticesForCase[tmpCell.mgCase][0], this.verticesForCase[tmpCell.mgCase][1]);
+  }
+
+  
+  _renderInterpolatedLines(cell){
+    if (cell.mgCase == undefined) { return; }
+    if (cell.mgCase == 0 || cell.mgCase == 15) { 
+      return;
+    }
+
+    if (cell.mgCase == 5 || cell.mgCase == 10) { 
+      this.drawLine(this.pointsForCase[cell.mgCase][0][0], this.pointsForCase[cell.mgCase][0][1]);
+      this.drawLine(this.pointsForCase[cell.mgCase][1][0], this.pointsForCase[cell.mgCase][1][1]);
+      return;
+    }
+    this.drawLine(this.pointsForCase[cell.mgCase][0], this.pointsForCase[cell.mgCase][1]);
   }
 
   _drawFromTo(x, y, fromIdx, toIdx){


### PR DESCRIPTION
Nothing terribly significant

re: the pixel rendering threshold, this will ultimately be sketch dependent.
... testing here shows that it was beneficial at `6 pixels` (previously used 4 pixels as cutoff).

----

### Metrics

*Using rect()*
... at 900x900 with cellWidth = 6px
![01_900x900_cw6_viaRect--DroppedFrames--Screenshot 2025-01-28 214306](https://github.com/user-attachments/assets/7552363c-6064-4829-afaf-cd8b7a295dcc)


*Using pixels*
... at 900x900 with cellWidth = 6px
![01-900x900_cw6-viaPixels--Screenshot 2025-01-28 213402](https://github.com/user-attachments/assets/9bdfd898-0246-47eb-bc20-aaead472018c)

