### PR TITLE
p5js/forest - MINOR - adjust trunk size based on age

### DIFF
--- a/p5js/forest-01/classes/tree.js
+++ b/p5js/forest-01/classes/tree.js
@@ -61,7 +61,8 @@ class Tree {
     noStroke();
     fill(100, 200, 100);
     rectMode(CENTER);
-    rect(this.x, this.y, 10, 10);
+    let trunkSize = lerp(1, 10, this.age / Tree.MAX_AGE);
+    rect(this.x, this.y, trunkSize, trunkSize);
 
     let shadowWidth = this.shadowRadius() * 2;
     fill(200, 200, 200, 50);


### PR DESCRIPTION
I feel this reduces the effect of the flickering when lots of trees are dropping seeds;

Seeing ~1px pop on and then off the screen is a lot less jarring than a 10x10 px square.