### PR TITLE
p5js/forest-02 - Refactor to TreeSpecies object (away from static class variables)

### DIFF
--- a/p5js/forest-02/README.md
+++ b/p5js/forest-02/README.md
@@ -2,6 +2,25 @@
 
 This is a [p5.js][p5js-home] sketch is a basic simulation of a forest by way of representations of individual trees.
 
+Trees are draw as green rectangles denoting their trunk, and growing circles that denote how big their `shadowRadius` (intended as a function of height and fullness, though not fully implemented yet).
+
+Their `shadowRadius` is also a simple model of the area that they compete with neighboring trees for resources. There are two types of resources modeled, sunlight and soil/water. 
+
+When trees resource area overlap, the taller tree doesn't loss any of the sunlight, but the lower tree is said to lose 50% of the sunlight it would have received. The soil resources (of the overlapping area) are split between the two trees.
+
+Trees grow (or diminish) based on the resources they are able to collect. The amount of resources a tree needs is a function of how big it is. On each cycle, the tree claims resources (based on competition), as determined of a percent of its maximum resources; note this value can be negative if its neighbors claim its resources
+
+Trees progress through various life cycle stages:
+
+* Sapling - Characterized by rapid growth (up to 20% of max height)
+* Mid-growth - (Up to full maturity) Characterized by slower growth, but likely not susceptible to foraging.
+    - At a certain point, the trees are able to start to produce seeds that will grow into other saplings. 
+* Decline - The years between full maturation and where the tree starts to lose its crown and eventually die off.
+
+Trees can die off due to foraging during their early years. The years of susceptibility is hard-coded to 10 years, but the rate of foraging is configurable.
+
+Trees send out seeds (based on seasonal cycle) once they reach a particular age. The number of seeds dropped, as well as how far from the tree they can be dropped, and the age at which a tree will start producing seeds are all configurable. 
+
 ## Controls
 
 Keyboard 

--- a/p5js/forest-02/classes/forest.js
+++ b/p5js/forest-02/classes/forest.js
@@ -120,7 +120,7 @@ class Forest {
   }
 
   tickStartOfSpringBehavior(){
-    this.trees.filter(t => t.age > Tree.AGE_TO_MAKE_SEEDS)
+    this.trees.filter(t => t.age > t.species.ageToMakeSeeds)
               .map(t => this.seedsForTree(t))
               .flat()
               .forEach(s => this.sproutTree(s.x, s.y));

--- a/p5js/forest-02/classes/forest.js
+++ b/p5js/forest-02/classes/forest.js
@@ -6,6 +6,9 @@ class Forest {
     this.trees = [];
     this.treeCounter = 0;
 
+    this.treeSpecies = [];
+    this.treeSpecies.push(new TreeSpecies());
+
     for (var i = 0; i < this.params.initial_trees; i++){
       let tmpX = this.centerX + (random() - 0.5) * this.width * 0.8;
       let tmpY = this.centerY + (random() - 0.5) * this.height * 0.8;
@@ -20,8 +23,9 @@ class Forest {
   get width()  { return this.area._width; }
   get height() { return this.area._height; }
 
-  sproutTree(x, y){
-    this.trees.push( new Tree(x, y, 0, this.treeCounter++) );
+  sproutTree(x, y, speciesIndex = 0){
+    this.trees.push( new Tree(x, y, 0, this.treeCounter++,
+                        this.treeSpecies[speciesIndex]) );
   }
 
   tick(){
@@ -38,7 +42,7 @@ class Forest {
   }
 
   lossDueToMaxAge(){
-    this.trees = this.trees.filter(t => t.age < Tree.MAX_AGE);
+    this.trees = this.trees.filter(t => t.age < t.species.maxAge);
   }
 
   lossDueToForaging(){

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -13,7 +13,6 @@ class Tree {
   static get YEARS_AS_SAPLING() { return systemParams.tree.years_as_sapling; }
   static get YEARS_AS_MATURE() { return systemParams.tree.years_as_mature;  }
   static get MAX_SHADOW_RADIUS() { return 100; }
-  static get AGE_TO_MAKE_SEEDS() { return systemParams.tree.age_to_make_seeds;  }
   static get MAX_HEIGHT() { return 15; } // in meters
   static get IDEALIZED_GROWTH_WHILE_SAPLING() { 
     return 0.2 * Tree.MAX_HEIGHT / (Tree.YEARS_AS_SAPLING / System.YEARS_PER_TICK);

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -10,15 +10,13 @@ class Tree {
     this.species = species;
   }
 
-  static get YEARS_AS_SAPLING() { return systemParams.tree.years_as_sapling; }
-  static get YEARS_AS_MATURE() { return systemParams.tree.years_as_mature;  }
   static get MAX_SHADOW_RADIUS() { return 100; }
   static get MAX_HEIGHT() { return 15; } // in meters
-  static get IDEALIZED_GROWTH_WHILE_SAPLING() { 
-    return 0.2 * Tree.MAX_HEIGHT / (Tree.YEARS_AS_SAPLING / System.YEARS_PER_TICK);
+  get IDEALIZED_GROWTH_WHILE_SAPLING() { 
+    return 0.2 * Tree.MAX_HEIGHT / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
   }
-  static get IDEALIZED_GROWTH_WHILE_MATURE() { 
-    return 0.8 * Tree.MAX_HEIGHT / (Tree.YEARS_AS_MATURE / System.YEARS_PER_TICK);
+  get IDEALIZED_GROWTH_WHILE_MATURE() { 
+    return 0.8 * Tree.MAX_HEIGHT / (this.species.yearsAsMature / System.YEARS_PER_TICK);
   }
   static get FULLNESS_RESILIENCY() { return 0.5 / (3 / System.YEARS_PER_TICK); }
   static get FULLNESS_VULNERABILITY() { return (2 / System.YEARS_PER_TICK); }
@@ -35,10 +33,10 @@ class Tree {
   }
 
   growthRate(){
-    if (this.age < Tree.YEARS_AS_SAPLING) {
-      return Tree.IDEALIZED_GROWTH_WHILE_SAPLING;
-    }else if (this.age < (Tree.YEARS_AS_SAPLING + Tree.YEARS_AS_MATURE)) {
-      return Tree.IDEALIZED_GROWTH_WHILE_MATURE;
+    if (this.age < this.species.yearsAsSapling) {
+      return this.IDEALIZED_GROWTH_WHILE_SAPLING;
+    }else if (this.age < (this.species.yearsAsSapling + this.species.yearsAsMature)) {
+      return this.IDEALIZED_GROWTH_WHILE_MATURE;
     }else {
       return 0;
     }
@@ -71,12 +69,12 @@ class Tree {
 
   shadowRadius(){
     let shadowFactor = 0;
-    if (this.age < Tree.YEARS_AS_SAPLING) {
-      shadowFactor = map(this.age, 0, Tree.YEARS_AS_SAPLING, 0.00001, 0.2);
-    } else if (this.age < Tree.YEARS_AS_MATURE) {
-      shadowFactor = map(this.age, Tree.YEARS_AS_SAPLING, Tree.YEARS_AS_MATURE, 0.2, 1);
+    if (this.age < this.species.yearsAsSapling) {
+      shadowFactor = map(this.age, 0, this.species.yearsAsSapling, 0.00001, 0.2);
+    } else if (this.age < this.species.yearsAsMature) {
+      shadowFactor = map(this.age, this.species.yearsAsSapling, this.species.yearsAsMature, 0.2, 1);
     } else {
-      shadowFactor = map(this.age, Tree.YEARS_AS_MATURE, this.species.maxAge, 1, 0.8);
+      shadowFactor = map(this.age, this.species.yearsAsMature, this.species.maxAge, 1, 0.8);
     }
     return shadowFactor * Tree.MAX_SHADOW_RADIUS;
   }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -10,14 +10,14 @@ class Tree {
     this.species = species;
   }
 
-  get IDEALIZED_GROWTH_WHILE_SAPLING() { 
+  idealizedGrowthAsSapling() { 
     return this.species.growRateWhileSapling * this.species.maxHeight / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
   }
-  get IDEALIZED_GROWTH_WHILE_MATURE() { 
+  idealizedGrowthAsMature() { 
     return this.species.growRateWhileMature * this.species.maxHeight / (this.species.yearsAsMature / System.YEARS_PER_TICK);
   }
-  static get FULLNESS_RESILIENCY() { return 0.5 / (3 / System.YEARS_PER_TICK); }
-  static get FULLNESS_VULNERABILITY() { return (2 / System.YEARS_PER_TICK); }
+  fullnessResiliency() { return this.species.fullnessResilencyFactor / (3 / System.YEARS_PER_TICK); }
+  fullnessVulnerability() { return (this.species.fullnessVulnerabilityFactor / System.YEARS_PER_TICK); }
 
   tick(resources){
     this.age += System.YEARS_PER_TICK;
@@ -32,9 +32,9 @@ class Tree {
 
   growthRate(){
     if (this.age < this.species.yearsAsSapling) {
-      return this.IDEALIZED_GROWTH_WHILE_SAPLING;
+      return this.idealizedGrowthAsSapling();
     }else if (this.age < (this.species.yearsAsSapling + this.species.yearsAsMature)) {
-      return this.IDEALIZED_GROWTH_WHILE_MATURE;
+      return this.idealizedGrowthAsMature();
     }else {
       return 0;
     }
@@ -43,12 +43,12 @@ class Tree {
   adjustFullness(resources){
     let deltaFullness = 0;
     if (resources === 1){
-      deltaFullness = (1 - this.fullness) * Tree.FULLNESS_RESILIENCY;
+      deltaFullness = (1 - this.fullness) * this.fullnessResiliency();
     } else if (resources < 0){
-      deltaFullness = Tree.FULLNESS_VULNERABILITY * (resources - 1);
+      deltaFullness = this.fullnessVulnerability() * (resources - 1);
     } else {
       // between 0-1, fullness should tend towards the 'resources' its receiving
-      deltaFullness = (resources - this.fullness) * Tree.FULLNESS_RESILIENCY;
+      deltaFullness = (resources - this.fullness) * this.fullnessResiliency();
     }
     this.fullness = constrain(this.fullness + deltaFullness, 0, 1);
   }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -11,10 +11,10 @@ class Tree {
   }
 
   get IDEALIZED_GROWTH_WHILE_SAPLING() { 
-    return 0.2 * this.species.maxHeight / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
+    return this.species.growRateWhileSapling * this.species.maxHeight / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
   }
   get IDEALIZED_GROWTH_WHILE_MATURE() { 
-    return 0.8 * this.species.maxHeight / (this.species.yearsAsMature / System.YEARS_PER_TICK);
+    return this.species.growRateWhileMature * this.species.maxHeight / (this.species.yearsAsMature / System.YEARS_PER_TICK);
   }
   static get FULLNESS_RESILIENCY() { return 0.5 / (3 / System.YEARS_PER_TICK); }
   static get FULLNESS_VULNERABILITY() { return (2 / System.YEARS_PER_TICK); }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -1,14 +1,15 @@
 class Tree {
-  constructor(x, y, age, id){
+  constructor(x, y, age, id, species){
     this.id = id;
     this.x = x;
     this.y = y;
     this.age = age;
     this.height = 0;
     this.fullness = 1;
+
+    this.species = species;
   }
 
-  static get MAX_AGE() { return systemParams.tree.max_age; } // in years
   static get YEARS_AS_SAPLING() { return systemParams.tree.years_as_sapling; }
   static get YEARS_AS_MATURE() { return systemParams.tree.years_as_mature;  }
   static get MAX_SHADOW_RADIUS() { return 100; }
@@ -61,7 +62,7 @@ class Tree {
     noStroke();
     fill(100, 200, 100);
     rectMode(CENTER);
-    let trunkSize = lerp(1, 10, this.age / Tree.MAX_AGE);
+    let trunkSize = lerp(1, 10, this.age / this.species.maxAge);
     rect(this.x, this.y, trunkSize, trunkSize);
 
     let shadowWidth = this.shadowRadius() * 2;
@@ -76,7 +77,7 @@ class Tree {
     } else if (this.age < Tree.YEARS_AS_MATURE) {
       shadowFactor = map(this.age, Tree.YEARS_AS_SAPLING, Tree.YEARS_AS_MATURE, 0.2, 1);
     } else {
-      shadowFactor = map(this.age, Tree.YEARS_AS_MATURE, Tree.MAX_AGE, 1, 0.8);
+      shadowFactor = map(this.age, Tree.YEARS_AS_MATURE, this.species.maxAge, 1, 0.8);
     }
     return shadowFactor * Tree.MAX_SHADOW_RADIUS;
   }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -55,7 +55,7 @@ class Tree {
 
   draw(){
     noStroke();
-    fill(100, 200, 100);
+    fill(this.species.trunkColor);
     rectMode(CENTER);
     let trunkSize = lerp(1, 10, this.age / this.species.maxAge);
     rect(this.x, this.y, trunkSize, trunkSize);

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -10,7 +10,6 @@ class Tree {
     this.species = species;
   }
 
-  static get MAX_SHADOW_RADIUS() { return 100; }
   static get MAX_HEIGHT() { return 15; } // in meters
   get IDEALIZED_GROWTH_WHILE_SAPLING() { 
     return 0.2 * Tree.MAX_HEIGHT / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
@@ -76,6 +75,6 @@ class Tree {
     } else {
       shadowFactor = map(this.age, this.species.yearsAsMature, this.species.maxAge, 1, 0.8);
     }
-    return shadowFactor * Tree.MAX_SHADOW_RADIUS;
+    return shadowFactor * this.species.maxShadowRadius;
   }
 }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -61,7 +61,8 @@ class Tree {
     noStroke();
     fill(100, 200, 100);
     rectMode(CENTER);
-    rect(this.x, this.y, 10, 10);
+    let trunkSize = lerp(1, 10, this.age / Tree.MAX_AGE);
+    rect(this.x, this.y, trunkSize, trunkSize);
 
     let shadowWidth = this.shadowRadius() * 2;
     fill(200, 200, 200, 50);

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -10,12 +10,11 @@ class Tree {
     this.species = species;
   }
 
-  static get MAX_HEIGHT() { return 15; } // in meters
   get IDEALIZED_GROWTH_WHILE_SAPLING() { 
-    return 0.2 * Tree.MAX_HEIGHT / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
+    return 0.2 * this.species.maxHeight / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
   }
   get IDEALIZED_GROWTH_WHILE_MATURE() { 
-    return 0.8 * Tree.MAX_HEIGHT / (this.species.yearsAsMature / System.YEARS_PER_TICK);
+    return 0.8 * this.species.maxHeight / (this.species.yearsAsMature / System.YEARS_PER_TICK);
   }
   static get FULLNESS_RESILIENCY() { return 0.5 / (3 / System.YEARS_PER_TICK); }
   static get FULLNESS_VULNERABILITY() { return (2 / System.YEARS_PER_TICK); }

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -5,7 +5,7 @@ class TreeSpecies {
     this.maxAge = 200;
     this.yearsAsSapling = 4;
     this.yearsAsMature = 140;
-    this.max_shadow_radius = 100;
+    this.maxShadowRadius = 100;
     this.ageToMakeSeeds = 40;
     this.max_height = 15;
     this.grow_rate_while_sapling = 0.2;

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -1,7 +1,7 @@
 class TreeSpecies {
   constructor(){
     this.name = "Species 1";
-    this.trunk_color = color(100, 200, 100);
+    this.trunkColor = color(100, 200, 100);
     this.maxAge = 200;
     this.yearsAsSapling = 4;
     this.yearsAsMature = 140;

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -8,8 +8,8 @@ class TreeSpecies {
     this.maxShadowRadius = 100;
     this.ageToMakeSeeds = 40;
     this.maxHeight = 15;
-    this.grow_rate_while_sapling = 0.2;
-    this.grow_rate_while_mature = 0.8;
+    this.growRateWhileSapling = 0.2;
+    this.growRateWhileMature = 0.8;
     this.fullness_resilency_factor =  0.5;
     this.fullness_vulnerability = 2;
 

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -7,7 +7,7 @@ class TreeSpecies {
     this.yearsAsMature = 140;
     this.maxShadowRadius = 100;
     this.ageToMakeSeeds = 40;
-    this.max_height = 15;
+    this.maxHeight = 15;
     this.grow_rate_while_sapling = 0.2;
     this.grow_rate_while_mature = 0.8;
     this.fullness_resilency_factor =  0.5;

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -3,8 +3,8 @@ class TreeSpecies {
     this.name = "Species 1";
     this.trunk_color = color(100, 200, 100);
     this.maxAge = 200;
-    this.years_as_sapling = 4;
-    this.years_as_mature = 140;
+    this.yearsAsSapling = 4;
+    this.yearsAsMature = 140;
     this.max_shadow_radius = 100;
     this.ageToMakeSeeds = 40;
     this.max_height = 15;

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -1,0 +1,20 @@
+class TreeSpecies {
+  constructor(){
+    this.name = "Species 1";
+    this.trunk_color = color(100, 200, 100);
+    this.maxAge = 200;
+    this.years_as_sapling = 4;
+    this.years_as_mature = 140;
+    this.max_shadow_radius = 100;
+    this.age_to_make_seeds = 10;
+    this.max_height = 15;
+    this.grow_rate_while_sapling = 0.2;
+    this.grow_rate_while_mature = 0.8;
+    this.fullness_resilency_factor =  0.5;
+    this.fullness_vulnerability = 2;
+
+    this.seeds_per_tree = 2;
+    this.seed_drop_dist = 30;
+    // this.is_foraged = true; // All trees are foraged for now
+  }
+}

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -6,7 +6,7 @@ class TreeSpecies {
     this.years_as_sapling = 4;
     this.years_as_mature = 140;
     this.max_shadow_radius = 100;
-    this.age_to_make_seeds = 10;
+    this.ageToMakeSeeds = 40;
     this.max_height = 15;
     this.grow_rate_while_sapling = 0.2;
     this.grow_rate_while_mature = 0.8;

--- a/p5js/forest-02/classes/tree_species.js
+++ b/p5js/forest-02/classes/tree_species.js
@@ -10,8 +10,8 @@ class TreeSpecies {
     this.maxHeight = 15;
     this.growRateWhileSapling = 0.2;
     this.growRateWhileMature = 0.8;
-    this.fullness_resilency_factor =  0.5;
-    this.fullness_vulnerability = 2;
+    this.fullnessResilencyFactor =  0.5;
+    this.fullnessVulnerabilityFactor = 2;
 
     this.seeds_per_tree = 2;
     this.seed_drop_dist = 30;

--- a/p5js/forest-02/index.md
+++ b/p5js/forest-02/index.md
@@ -19,6 +19,7 @@ js_scripts:
 - classes/cell_viewer.js
 - classes/system.js
 - classes/tree.js
+- classes/tree_species.js
 - classes/forest.js
 - classes/seasonal_time.js
 - app.js

--- a/p5js/forest-02/local_dev.html
+++ b/p5js/forest-02/local_dev.html
@@ -15,6 +15,7 @@
     <script src="classes/cell_viewer.js"></script>
     <script src="classes/system.js"></script>
     <script src="classes/tree.js"></script>
+    <script src="classes/tree_species.js"></script>
     <script src="classes/forest.js"></script>
     <script src="classes/seasonal_time.js"></script>
     <script src="app.js" charset="utf-8"></script>


### PR DESCRIPTION
Not sure what my thought process was several years ago.

But prior implementation would have required subclasses to redefine these 'property' functions.

This splits out the parameters to a Species object; which will allow others to be created, while using the same general 'Tree' engine.