### PR TITLE
p5j/forest-02 Optimize via variable caching and use of Quadtree

### DIFF
--- a/js/models/quadtree.js
+++ b/js/models/quadtree.js
@@ -40,9 +40,8 @@ class Quadtree {
         return this.objects.filter(obj => Rect.rectContainsXY(obj, queryObj.x, queryObj.y));
         
       } else {
-        // Assume query object is a Rect {x, y, width, height}
-        // TODO: Add Rect.overlaps() UNSUPPORTED 
-        // return this.objects.filter(obj => queryObj.overlaps(obj));
+        // Assume query object is a Rect-duck {x, y, width, height}
+        return this.objects.filter(obj => Rect.rectContainsObject(queryObj, obj));
       }
     }
   }

--- a/js/models/rect.js
+++ b/js/models/rect.js
@@ -42,6 +42,14 @@ class Rect {
             && this.minY < otherRect.minY && this.maxY > otherRect.maxY;
   }
 
+  overlaps(otherRect){
+    if ((this._x + this._width) < otherRect._x) { return false; }
+    if ((this._y + this._height) < otherRect._y) { return false; }
+    if ((otherRect._x + otherRect._width) < this._x) { return false; }
+    if ((otherRect._y + otherRect._height) < this._y) { return false; }
+    return true;
+  }
+
   expandToIncludeRect(otherRect){
     let maxX = this.maxX;
     let maxY = this.maxY;
@@ -59,6 +67,15 @@ class Rect {
   static rectContainsXY(rect1, x, y){
     return rect1.x <= x && x < (rect1.x + rect1.width)
            && rect1.y <= y && y < (rect1.y + rect1.height);
+  }
+
+  // These merely need to be rect-ducks, responding to .x .y and .width and .height
+  static rectContainsObject(rect1, otherRect){
+    if ((rect1.x + rect1.width) < otherRect.x) { return false; }
+    if ((rect1.y + rect1.height) < otherRect.y) { return false; }
+    if ((otherRect.x + otherRect.width) < rect1.x) { return false; }
+    if ((otherRect.y + otherRect.height) < rect1.y) { return false; }
+    return true;
   }
 
   containsXY(x, y){ 

--- a/p5js/common/examples/quadtree-2/app.js
+++ b/p5js/common/examples/quadtree-2/app.js
@@ -1,10 +1,21 @@
 var canvas;
 var quadtree;
 let lastTouch;
+let gui; 
+
+let settings = {
+  check_by_point: false,
+  query_rect_size: 30
+}
+
 
 function setup() {
   createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
+
+  gui = P5JsSettings.addDatGui({autoPlace: false});
+  gui.add(settings, 'check_by_point');
+  gui.add(settings, 'query_rect_size', 6, 100, 2);
 
   let fullCanvas = new Rect(0, 0, width, height);
   quadtree = new Quadtree(fullCanvas, 5, false);
@@ -33,8 +44,8 @@ function touchMoved(){
 }
 
 function addRandomRects(){
+  let tmpRect;
   for (let i = 0; i < 300; i++){
-
     quadtree.add({x: randomGaussian(width/2, width/4),
                   y: randomGaussian(height/2, height/4),
                   width: 5 + random(40),
@@ -58,13 +69,21 @@ function drawQuadtree(qt){
 }
 
 function highlightUnderMouse(){
-  let objects;
-  if (lastTouch){
-    objects = quadtree.find(lastTouch);
-  } else {
-    objects = quadtree.find({x: mouseX, y: mouseY});
-  }
+  let cursorPt =  (lastTouch) ? lastTouch : {x: mouseX, y: mouseY};
+  let queryObj = cursorPt;
   
+  if (settings.check_by_point == false) {
+    
+    queryObj = new Rect(cursorPt.x - settings.query_rect_size / 2, 
+                        cursorPt.y - settings.query_rect_size / 2,
+                      settings.query_rect_size, settings.query_rect_size)
+    
+    strokeWeight(2);
+    stroke(230, 0, 0);
+    P5JsUtils.drawRect(queryObj);
+  }
+  let objects = quadtree.find(queryObj);
+
   strokeWeight(2);
   stroke(230, 230, 0);
 

--- a/p5js/common/examples/quadtree-2/index.md
+++ b/p5js/common/examples/quadtree-2/index.md
@@ -7,6 +7,7 @@ excerpt: Implementation of a quadtree data structure, which groups data points i
 
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.js
+- /sketchbook/vendor/dat.gui/0.7.9/dat.gui.min.js
 - /sketchbook/p5js/common/p5js_settings.js
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js

--- a/p5js/common/examples/quadtree-2/local_dev.html
+++ b/p5js/common/examples/quadtree-2/local_dev.html
@@ -6,6 +6,7 @@
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.1/inobounce.js" charset="utf-8"></script>
     <script src="/sketchbook/vendor/p5.js/0.7.2/p5.js" charset="utf-8"></script>
+    <script src="/sketchbook/vendor/dat.gui/0.7.9/dat.gui.min.js"></script>
     <script src="/sketchbook/p5js/common/p5js_settings.js" charset="utf-8"></script>
     <script src="/sketchbook/p5js/common/p5js_utils.js" charset="utf-8"></script>
     <script src="/sketchbook/js/util_functions.js" charset="utf-8"></script>

--- a/p5js/forest-02/app.js
+++ b/p5js/forest-02/app.js
@@ -16,26 +16,30 @@ var systemParams = {
 };
 
 function setup() {
-  createCanvas(500, 500);
-  // createCanvas(windowWidth, windowHeight-35);
+  // createCanvas(500, 500);
+  createCanvas(windowWidth, windowHeight-35);
   P5JsSettings.init();
 
   gui = P5JsSettings.addDatGui({autoPlace: false});
-  gui.add(systemParams, 'foraging_rate').min(0.1).max(0.9).step(0.05);
-  gui.add(systemParams, 'seeds_per_tree').min(1).max(20).step(1);
-  gui.add(systemParams, 'seed_drop_dist').min(1).max(150).step(10);
-  gui.add(systemParams, 'initial_trees').min(1).max(50).step(1);
   gui.add(systemParams, "paused");
+  let forestGui = gui.addFolder('Forest Attributes');
+  forestGui.open();
+  forestGui.add(systemParams, 'foraging_rate').min(0.1).max(0.9).step(0.05);
+  forestGui.add(systemParams, 'initial_trees').min(1).max(50).step(1);
 
-  let treeCfg = gui.addFolder('Tree Attributes');
-  treeCfg.add(systemParams.tree, 'max_age').min(20).max(500).step(5);
-  treeCfg.add(systemParams.tree, 'years_as_sapling').min(3).max(30).step(1);
-  treeCfg.add(systemParams.tree, 'years_as_mature').min(15).max(300).step(5);
-  treeCfg.add(systemParams.tree, 'age_to_make_seeds').min(3).max(60).step(3);
+  // let treeCfg = gui.addFolder('Tree Attributes');
+  // treeCfg.add(systemParams.tree, 'max_age').min(20).max(500).step(5);
+  // treeCfg.add(systemParams.tree, 'years_as_sapling').min(3).max(30).step(1);
+  // treeCfg.add(systemParams.tree, 'years_as_mature').min(15).max(300).step(5);
+  // treeCfg.add(systemParams.tree, 'age_to_make_seeds').min(3).max(60).step(3);
+  // treeCfg.add(systemParams, 'seed_drop_dist').min(1).max(150).step(10);
+  // treeCfg.add(systemParams, 'seeds_per_tree').min(1).max(20).step(1);
   
   let rect = new Rect(0, 0, width, height);
   system = new System(rect, systemParams);
   system.init();
+
+  forestGui.add(system.forest, 'treeLimit', 50, 5000, 50);
 }
 
 function keyPressed() {

--- a/p5js/forest-02/classes/forest.js
+++ b/p5js/forest-02/classes/forest.js
@@ -153,8 +153,8 @@ class Forest {
 
   seedsForTree(tree){
     let seedLocations = [];
-    let numSeeds = this.params.seeds_per_tree;
-    let stdDevDropDistance = this.params.seed_drop_dist;
+    let numSeeds = tree.species.seeds_per_tree;
+    let stdDevDropDistance = tree.species.seed_drop_dist;
     for (var i=0; i<numSeeds; i++){
       seedLocations.push(
           {  x: randomGaussian(tree.x, stdDevDropDistance)

--- a/p5js/forest-02/classes/forest.js
+++ b/p5js/forest-02/classes/forest.js
@@ -11,6 +11,7 @@ class Forest {
     this.treeSpecies.push(TreeSpecies.SlowAndResilient);
     this.treeSpecies.push(TreeSpecies.FastShortWeak);
 
+    this.treeLimit = 1000;
 
     let speciesIndex;
     for (var i = 0; i < this.params.initial_trees; i++){
@@ -35,7 +36,7 @@ class Forest {
 
   sproutTreeForSpecies(x, y, species){
     // TODO: Remove this cap, or make more prominent
-    if (this.trees.length > 700) { 
+    if (this.trees.length > this.treeLimit) { 
       // consol/e.log('no more room at the inn');
       return; 
     }

--- a/p5js/forest-02/classes/tree.js
+++ b/p5js/forest-02/classes/tree.js
@@ -4,11 +4,15 @@ class Tree {
     this.x = x;
     this.y = y;
     this.age = age;
-    this.height = 0;
+    this.verticalExtent = 0;
     this.fullness = 1;
 
     this.species = species;
+    this.computeShadowRadius();
   }
+
+  get width() { return this.shadowRadius(); }
+  get height() { return this.shadowRadius(); }
 
   idealizedGrowthAsSapling() { 
     return this.species.growRateWhileSapling * this.species.maxHeight / (this.species.yearsAsSapling / System.YEARS_PER_TICK);
@@ -28,8 +32,9 @@ class Tree {
   // values 0 - 1
   tick(resources){
     this.age += System.YEARS_PER_TICK;
-    this.height += Math.max(resources, 0) * this.growthRate();
+    this.verticalExtent += Math.max(resources, 0) * this.growthRate();
     this.adjustFullness(resources);
+    this.computeShadowRadius();
   }
 
   distFrom(otherTree){
@@ -74,7 +79,8 @@ class Tree {
     ellipse(this.x, this.y, shadowWidth, shadowWidth);
   }
 
-  shadowRadius(){
+  shadowRadius(){ return this._shadowRadius; }
+  computeShadowRadius(){
     // TODO: Factor in Fullness
     // TODO: Split from above and below ground
     let shadowFactor = 0;
@@ -85,6 +91,6 @@ class Tree {
     } else {
       shadowFactor = map(this.age, this.species.yearsAsMature, this.species.maxAge, 1, 0.8);
     }
-    return shadowFactor * this.species.maxShadowRadius;
+    this._shadowRadius =  shadowFactor * this.species.maxShadowRadius;
   }
 }

--- a/p5js/forest-02/index.md
+++ b/p5js/forest-02/index.md
@@ -13,6 +13,7 @@ js_scripts:
 - /sketchbook/js/util_functions.js
 - /sketchbook/js/options_set.js
 - /sketchbook/js/models/rect.js
+- /sketchbook/js/models/quadtree.js
 - /sketchbook/js/models/cell_grid.js
 - classes/cell.js
 - classes/cell_viewer.js

--- a/p5js/forest-02/local_dev.html
+++ b/p5js/forest-02/local_dev.html
@@ -9,6 +9,7 @@
     <script src="/sketchbook/js/util_functions.js"></script>
     <script src="/sketchbook/js/options_set.js"></script>
     <script src="/sketchbook/js/models/rect.js"></script>
+    <script src="/sketchbook/js/models/quadtree.js"></script>
     <script src="/sketchbook/js/models/cell_grid.js" charset="utf-8"></script>
 
     <script src="classes/cell.js"></script>


### PR DESCRIPTION
Main commit: https://github.com/brianhonohan/sketchbook/commit/756e7f54af9920a3739602f4403ca62e5f626224

This had significant overall improvement
- reduce time per frame from 39ms => 11 ms
- will be able to scale up the number of trees as well

Cache the shadowRadius rather than recompute on each request
- this cut the time-per frame by more than half
- from 39 ms ==> 17ms

Use a Quadtree to reduce the number of 'dist' (square root) calcs necessary for checking if two trees overlap.

Had to refactor name of tree.height to tree.verticalExtent
- To allow for using 'height' as the width/height (on 2D screen) of where the area the tree occupies;
- Thus allow Tree objects to be placed directly into Quadtree (2D search structure)


Made possible by: https://github.com/brianhonohan/sketchbook/commit/ea10d0bc8d1325a9e358c9528fef95a57f60fa13 
- which allows for querying a `Quadtree` via a 'rect' like object
- updated example: https://brianhonohan.com/sketchbook/p5js/common/examples/quadtree-2/


----

### Perf details


* Before ... ~ 39 ms per frame

![01--PreOpt--Limit-500---NoQuadTree--RecalcShadowRadius--Screenshot 2025-02-11 225011](https://github.com/user-attachments/assets/d3f21a91-6565-4c84-a108-e9a187f2c2ee)


* Optimization 1
- Refactor `Tree.shadowRadius()` to return a computed value (that is recomputed once per frame)
- reduced frame time from 39ms to 16.5 ms

![02--Opt--Limit-500---NoQuadTree--CacheShadowRadius--Screenshot 2025-02-11 225533](https://github.com/user-attachments/assets/1993f1d3-abfb-4ac9-b763-4d6a1d908754)


* Optimization 2
- Use quadtree to look up competing trees
- this reduces the number of `dist()` calls that are made, reducing from O(n^2) to not that.
- further reduces frame time from 16.5ms to ~11 ms 
- 
![03--Opt--Limit-500---QuadTree--CacheShadowRadius--Screenshot 2025-02-11 225743](https://github.com/user-attachments/assets/46c81fd0-3042-4f32-a9da-2a5af14e480f)

