### PR TITLE
p5js/paisley - Update polybezier curves rather than create new ones when moving the curve 

### DIFF
--- a/p5js/common/examples/bezier-2/app.js
+++ b/p5js/common/examples/bezier-2/app.js
@@ -12,7 +12,9 @@ const settings = {
     percent: 0.25,
     perpendicular: true,
     perpendicular_length: 50
-  }
+  },
+  reset: resetShapes,
+  makeCircleArc: makeCircleArc
 }
 
 function setup() {
@@ -23,8 +25,10 @@ function setup() {
 
   pointsAlongCurve = [];
   
-  gui = P5JsSettings.addDatGui({autoPlace: false});
+  gui = P5JsSettings.addGui({autoPlace: false});
   gui.add(settings, "enable_drag").onChange(updateDragEnabled);
+  gui.add(settings, "reset");
+  gui.add(settings, "makeCircleArc");
   let pointsGui = gui.addFolder("Points Along Curve Debug");
   pointsGui.open();
   pointsGui.add(settings, "num_points", 0, 20, 1).onChange(drawIntermediatePoints);
@@ -69,6 +73,11 @@ function draw(){
       perpendicularLine.draw();
     }
   }
+}
+
+function makeCircleArc(){
+  const radius = 0.3 * width;
+  shapes[0].makeCircleQuarterArc(width/2 - radius/2, height/2 + radius / 2, radius,- HALF_PI);
 }
 
 function updateDragEnabled(){

--- a/p5js/common/examples/bezier-2/index.md
+++ b/p5js/common/examples/bezier-2/index.md
@@ -9,7 +9,7 @@ excerpt: Demonstrates the additional functionality of a Bezier curve, to get poi
 js_scripts:
 - https://cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.0/inobounce.js
 - https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.2/p5.min.js
-- /sketchbook/vendor/dat.gui/0.7.7/dat.gui.js
+- https://cdn.jsdelivr.net/npm/lil-gui@0.20
 - /sketchbook/p5js/common/p5js_settings.js
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js

--- a/p5js/common/examples/bezier-2/local_dev.html
+++ b/p5js/common/examples/bezier-2/local_dev.html
@@ -8,7 +8,7 @@
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/inobounce/0.2.1/inobounce.js" charset="utf-8"></script>
     <script src="/sketchbook/vendor/p5.js/1.11.2/p5.min.js" charset="utf-8"></script>
-    <script src="/sketchbook/vendor/dat.gui/0.7.7/dat.gui.js"></script>
+    <script src="/sketchbook/vendor/lil-gui/0.20.0/lil-gui.min.js"></script>
     <script src="/sketchbook/p5js/common/p5js_settings.js" charset="utf-8"></script>
     <script src="/sketchbook/p5js/common/p5js_utils.js" charset="utf-8"></script>
     <script src="/sketchbook/js/util_functions.js" charset="utf-8"></script>

--- a/p5js/common/shapes/bezier_curve.js
+++ b/p5js/common/shapes/bezier_curve.js
@@ -28,6 +28,13 @@ class BezierCurve {
     }
   }
 
+  static defaultCurve(){
+    return new BezierCurve(0.2 * width, 0.8 * height,
+                            0.4 * width, 0.8 * height,
+                            0.6 * width, 0.2 * height,
+                            0.8 * width, 0.2 * height);
+  }
+
   static fromPoints(p1, p2, p3, p4){
     return new BezierCurve(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y, p4.x, p4.y);
   }

--- a/p5js/common/shapes/bezier_curve.js
+++ b/p5js/common/shapes/bezier_curve.js
@@ -3,21 +3,29 @@ class BezierCurve {
   // Point1, Point2, Point3, Point4
   // x1, y1, x2, y2, x3, y3, x4, y4
   constructor(a, b, c, d, x3, y3, x4, y4){
-    if (a.x && a.y){
-      this.p1 = new Point(a.x, a.y);
-      this.p2 = new Point(b.x, b.y);
-      this.p3 = new Point(c.x, c.y);
-      this.p4 = new Point(d.x, d.y);
-    } else {
-      this.p1 = new Point(a, b);
-      this.p2 = new Point(c, d);
-      this.p3 = new Point(x3, y3);
-      this.p4 = new Point(x4, y4);
-    }
+    this.p1 = new Point(0, 0);
+    this.p2 = new Point(0, 0);
+    this.p3 = new Point(0, 0);
+    this.p4 = new Point(0, 0);
+    this.updatePoints(a, b, c, d, x3, y3, x4, y4);
 
     this.dragEnabled = false;
     this.noFill = true;
     this.initPoints();
+  }
+
+  updatePoints(a, b, c, d, x3, y3, x4, y4){
+    if (a.x && a.y){
+      this.p1.set(a.x, a.y);
+      this.p2.set(b.x, b.y);
+      this.p3.set(c.x, c.y);
+      this.p4.set(d.x, d.y);
+    } else {
+      this.p1.set(a, b);
+      this.p2.set(c, d);
+      this.p3.set(x3, y3);
+      this.p4.set(x4, y4);
+    }
   }
 
   static fromPoints(p1, p2, p3, p4){
@@ -74,6 +82,12 @@ class BezierCurve {
   }
 
   static circularQuarterArc(x, y, radius, startAt){
+    let curve = new BezierCurve(0,0,0,0,0,0,0,0);
+    curve.makeCircleQuarterArc(x, y, radius, startAt);
+    return curve;
+  }
+
+  makeCircleQuarterArc(x, y, radius, startAt){
     // From: https://spencermortensen.com/articles/bezier-circle/
     // P0=(0,1), P1=(c,1), P2=(1,c), P3=(1,0)
     // c=0.551915024494
@@ -82,9 +96,9 @@ class BezierCurve {
     let c = scaledC;
     let l = radius;
 
-    let curve = new BezierCurve( l,  0,  l,  c,  c,  l,  0,  l);
-    curve.rotateAbout(0, 0, startAt);
-    curve.move(x, y);
+    this.updatePoints( l,  0,  l,  c,  c,  l,  0,  l);
+    this.rotateAbout(0, 0, startAt);
+    this.move(x, y);
     return curve;
   }
 

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -92,29 +92,35 @@ class Paisley {
     this.radiusPt.y = this.leftShoulderPt.y;
   }
 
+  get leftBulbCurve() { return this.polybezier[0]; }
+  get rightBulbCurve() { return this.polybezier[1]; }
+  get rightTailCurve() { return this.polybezier[2]; }
+  get leftTailCurve() { return this.polybezier[3]; }
+
   _initPolyBezier() {
     if (this.polybezier == undefined){
       this.polybezier = new Polybezier();
+      this.polybezier.push(BezierCurve.defaultCurve());
+      this.polybezier.push(BezierCurve.defaultCurve());
+      this.polybezier.push(BezierCurve.defaultCurve());
+      this.polybezier.push(BezierCurve.defaultCurve());
+
+      this.spine = BezierCurve.defaultCurve();
     }
 
-    this.spine = new BezierCurve(this.pos, this.spineConstraint, this.tail, this.tail);
+    this.spine.updatePoints(this.pos, this.spineConstraint, this.tail, this.tail);
+    this.leftBulbCurve.makeCircleQuarterArc(this.x, this.y, this.bulbRadius, this.heading - HALF_PI);
+    this.rightBulbCurve.makeCircleQuarterArc(this.x, this.y, this.bulbRadius, this.heading);
 
-    // TODO: Investigate moving existing curves rather than recreate them
-    this.polybezier.clear();
-    this.polybezier.append(BezierCurve.circularQuarterArc(this.x, this.y, this.bulbRadius, this.heading - HALF_PI));
-    this.polybezier.append(BezierCurve.circularQuarterArc(this.x, this.y, this.bulbRadius, this.heading));
-
-    let rightTail = new BezierCurve(this.rightShoulderPt,
+    this.rightTailCurve.updatePoints(this.rightShoulderPt,
                                     this.rightConstraint,
                                     this.tail,
                                     this.tail);
-    this.polybezier.append(rightTail);
 
-    let leftTail = new BezierCurve(this.tail, this.tail,
+    this.leftTailCurve.updatePoints(this.tail, this.tail,
                                     this.leftConstraint,
                                     this.leftShoulderPt
                                     );
-    this.polybezier.append(leftTail);
   }
 
   _initDefaultTail(){


### PR DESCRIPTION
Code refactor of sketch: https://brianhonohan.com/sketchbook/p5js/common/examples/paisley-2/


This makes use of the recently added ability to update bezier curves

Perf tests are virtually imperceptible difference; but its no worse than before, and at a minimum, this will allow attaching properties (eg. accents) to these objects while still being able to move them.