### PR TITLE
p5js/common/paisley - Improve the toCode() behavior to use relative dimensions

### DIFF
--- a/p5js/common/examples/paisley/app.js
+++ b/p5js/common/examples/paisley/app.js
@@ -45,8 +45,7 @@ function touchEnded(){
 function keyPressed(){
   switch(key){
     case 'c':
-      shapes.filter(s => s.isDragged == true)
-            .forEach(s => console.log(s._constructorCall()));
+      shapes.forEach(s => console.log(s.toCode()));
       break;
   }
 }

--- a/p5js/common/shapes/bezier_curve.js
+++ b/p5js/common/shapes/bezier_curve.js
@@ -197,7 +197,7 @@ class BezierCurve {
     const xJS = !proportionalToCanvas ? x => x : (x) => P5JsUtils.jsCodeAsWidthFraction(x);
     const yJS = !proportionalToCanvas ? y => y : (y) => P5JsUtils.jsCodeAsHeightFraction(y);
 
-    code.push(`let bezierCurve = new BezierCurve(${xJS(this.p1.x)}, ${yJS(this.p1.y)},`);
+    code.push(`const bezierCurve = new BezierCurve(${xJS(this.p1.x)}, ${yJS(this.p1.y)},`);
     code.push(`                                  ${xJS(this.p2.x)}, ${yJS(this.p2.y)},`);
     code.push(`                                  ${xJS(this.p3.x)}, ${yJS(this.p3.y)},`);
     code.push(`                                  ${xJS(this.p4.x)}, ${yJS(this.p4.y)});`);

--- a/p5js/common/shapes/paisley.js
+++ b/p5js/common/shapes/paisley.js
@@ -74,10 +74,18 @@ class Paisley {
     this._initPolyBezier();
   }
 
-  _constructorCall(){
-    return `new Paisley(${this.x}, ${this.y}, `
-            + `${this.heading}, ${this.bulbRadius},`
-            + `${this.tail.x}, ${this.tail.y});`;
+  toCode(proportionalToCanvas = false){
+    let code = []
+    const toTenths = (num) => (Math.round(num * 10) / 10).toFixed(1);
+    const xJS = !proportionalToCanvas ? x => toTenths(x) : (x) => P5JsUtils.jsCodeAsWidthFraction(x);
+    const yJS = !proportionalToCanvas ? y => toTenths(y) : (y) => P5JsUtils.jsCodeAsHeightFraction(y);
+    const indentation = !proportionalToCanvas ? '' : '                             ';
+    const joinChar = !proportionalToCanvas ? ' ' : char(10);
+
+    code.push(`const paisley = new Paisley(${xJS(this.x)}, ${yJS(this.y)},`);
+    code.push(`${indentation}${toTenths(this.heading)}, ${xJS(this.bulbRadius)},`);
+    code.push(`${indentation}${xJS(this.tail.x)}, ${yJS(this.tail.y)});`);
+    return code.join(joinChar);
   }
 
   get x() { return this.pos.x; }


### PR DESCRIPTION
Use the recently added jsCodeAsHeightFraction and jsCodeAsWidthFraction

Ultimately, this allows for basic output of code to generate the shapes.

two options:
`console.log(paisley.toCode())`

Gives a concise, albeit fixed sizing:

```javascript
const paisley = new Paisley(371.7, 462.0, 2.4, 99.1, 743.4, 369.6);
```

Passing in true gives dimensions relative to width/height: 
`console.log(paisley.toCode(true))`

```javascript
const paisley = new Paisley(0.30 * width, 0.50 * height,
                             2.4, 0.08 * width,
                             0.60 * width, 0.40 * height);
```