### PR TITLE
p5js/terrain Fix bugs in sizing, adjusting isoline count, and enable lerpped colors

### DIFF
--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -47,7 +47,7 @@ class CellGrid {
     return Math.ceil( (1.0 * rect.width)  / cellSize );
   }
   static getRowCount(rect, cellSize){
-    return Math.ceil( (1.0 * rect.width)  / cellSize );
+    return Math.ceil( (1.0 * rect.height)  / cellSize );
   }
 
   initCells() {

--- a/js/models/fields/discrete_field.js
+++ b/js/models/fields/discrete_field.js
@@ -18,7 +18,6 @@ class DiscreteField {
     this.values = [];
     this.minValue = 0;
     this.maxValue = 2;
-    this.refreshTiers();
   }
 
   resetToDefaultNoise(){
@@ -32,19 +31,20 @@ class DiscreteField {
     this.noiseFunction = noiseFunction;
   }
 
-  refreshTiers(){
-    this.isolines.refreshTiers();
-    this.tierBreakpoints = this.isolines.tierBreakpoints;
-    this.tierStep = this.isolines.tierStep;
-    this.tiers = this.isolines.tiers;
-    this.msquares = this.isolines.msquares;
-  }
-
   regenerate(){
     for(let i = 0; i < this.grid.numCells; i++){
       this.values[i] = this.getValueAt(Math.trunc(i / this.grid.numCols), i % this.grid.numCols);
     }
+    this.refreshTiers();
+  }
+
+  refreshTiers(){
+    this.isolines.refreshTiers();
     this.isolines.compute();
+    this.tierBreakpoints = this.isolines.tierBreakpoints;
+    this.tierStep = this.isolines.tierStep;
+    this.tiers = this.isolines.tiers;
+    this.msquares = this.isolines.msquares;
   }
 
   get range(){ 

--- a/js/models/fields/terrain.js
+++ b/js/models/fields/terrain.js
@@ -4,6 +4,6 @@ class Terrain extends DiscreteField {
     for(let i = 0; i < this.grid.numCells; i++){
       this.values[i] = -1 + this.getValueAt(Math.trunc(i / this.grid.numCols), i % this.grid.numCols);
     }
-    this.isolines.compute();
+    this.refreshTiers();
   }
 }

--- a/p5js/common/examples/terrain/app.js
+++ b/p5js/common/examples/terrain/app.js
@@ -26,6 +26,7 @@ function setup() {
   gui.add(system.settings, "rectPercent", 0.05, 1, 0.01).onChange(updateRendering);
   gui.add(system.settings, "drawGrid");
   gui.add(system.settings, "num_levels", 2, 20, 1).onChange(updateRendering);
+  gui.add(system.settings, "bin_colors", 2, 20, 1).onChange(updateRendering);
 }
 
 function regenerateSystem(){

--- a/p5js/common/examples/terrain/classes/system.js
+++ b/p5js/common/examples/terrain/classes/system.js
@@ -29,6 +29,7 @@ class System {
       { name: "open_simplex_noise", type: "bool", default: false},
       { name: "interpolate_lines", type: "bool", default: true},
       { name: "num_levels", type: "integer", default: 16},
+      { name: "bin_colors", type: "bool", default: false},
     ];
   }
 

--- a/p5js/common/fields/terrain_viewer.js
+++ b/p5js/common/fields/terrain_viewer.js
@@ -13,7 +13,7 @@ class TerrainViewer {
 
     this.gridColor = color(50, 200, 200);
 
-    this.precomputeVerticesForCase();
+    this.precomputeVerticesForCase(); 
     this.precomputePointsForCase();
     this.updateSettings();
   }
@@ -91,12 +91,17 @@ class TerrainViewer {
     if (this.cellWidth <= 4){
       return;
     }
+    
+    const colorForValueFunc = (this.system.settings.bin_colors) ?
+            (val) => { return this.colorRamp.getBinnedColorForValue(val) } :
+            (val) => { return this.colorRamp.getColorForValue(val) };
 
     noStroke();
     for(let i=0; i<field.values.length; i++){
       // if (field.values[i] < 1){ continue; }
-      // let c = this.colorRamp.getColorForValue(field.values[i]/2.0);
-      let c = this.colorRamp.getBinnedColorForValue(field.values[i]);
+      // let c = this.colorRamp.getColorForValue(field.values[i]);
+      // let c = this.colorRamp.getBinnedColorForValue(field.values[i])
+      let c = colorForValueFunc(field.values[i]);
 
       // if (c == undefined) {
       //   console.log(`undefined for:${i}`);


### PR DESCRIPTION
re: lerpped colors, did some performance tests

1. Used binned colors; though recompute bin for each value (could use tiers, if tiers aligned with color count; or tier for colors)
2. Use lerping to calc color per value
3. Allow for toggle at runtime via the modes, with lambda to avoid if() within forloop

Used same [seed ](http://localhost:8000/sketchbook/p5js/common/examples/terrain/local_dev.html?seed=3815215538196340) for all tests and kept window size the same.

------


### Test 1 
Summary data shows 65% of time in script

![01-always-bin-summary--65percent-script](https://github.com/user-attachments/assets/5060e07c-5811-4d15-ae18-c3918f2e2879)

![01-always-bin-the-colors](https://github.com/user-attachments/assets/8f6560c9-6cfa-4af7-9034-ab852230d3ba)


### Test 2 
Summary data shows ~98% in script

![02-always-lerp--98percent-script](https://github.com/user-attachments/assets/e0d59ec7-a501-4e87-95ac-2b53135723f5)

![02-always-lerp-the-colors](https://github.com/user-attachments/assets/aaea8b5b-ab30-4c27-9b95-6d40125f0f85)


### Test 3 
Toggling modes in UI

Seems to show some perf hit of lambda; mid section doesn't achieve the 27ms from test 1

![03-dynamic-user-preference](https://github.com/user-attachments/assets/2f2254e1-64d2-4b53-b18f-b8823c3358b6)





