### PR TITLE
p5js/common/terrain - MINOR fix bug with modifying display settings

### DIFF
--- a/p5js/common/examples/terrain/app.js
+++ b/p5js/common/examples/terrain/app.js
@@ -34,11 +34,11 @@ function setup() {
   terrainGui.add(system.settings, "open_simplex_noise").onChange(regenerateSystem);
   const displayGui = gui.addFolder('Display Settings');
   displayGui.add(system.settings, "interpolate_lines").onChange(regenerateSystem);
-  displayGui.add(system.settings, "drawLines");
-  displayGui.add(system.settings, "fillRect");
+  displayGui.add(system.settings, "drawLines").onChange(updateRendering);
+  displayGui.add(system.settings, "fillRect").onChange(updateRendering);
   displayGui.add(system.settings, "rectPercent", 0.05, 1, 0.01).onChange(updateRendering);
-  displayGui.add(system.settings, "drawGrid");
-  displayGui.add(system.settings, "gridResolution", 1, 40, 1);
+  displayGui.add(system.settings, "drawGrid").onChange(updateRendering);
+  displayGui.add(system.settings, "gridResolution", 1, 40, 1).onChange(updateRendering);
   displayGui.add(system.settings, "num_levels", 2, 20, 1).onChange(updateRendering);
   displayGui.add(system.settings, "bin_colors", 2, 20, 1).onChange(updateRendering); 
   gui.add(P5JsUtils, "toggleLoop").name('Pause'); // not great UI, for static sketches, it is unclear if paused or not.


### PR DESCRIPTION
Because we're now only redrawing if there is a reason to, we need to explicitly call updateRendering when these settings change