### PR TITLE
js/space-colonization Refactoring p5.js out of space-colonization classes

### DIFF
--- a/js/models/space-colonization/plant.js
+++ b/js/models/space-colonization/plant.js
@@ -15,7 +15,7 @@ class Plant {
     let firstSegment = new RootSegment(this.x, this.y + 10, this, this);
     this.addRootSegment(firstSegment);
 
-    let downward = createVector(0, 1);
+    let downward = new Vector2D(0, 1);
     let firstTip = new RootTip(this.x, this.y+10, firstSegment, downward, this);
 
     this.tips.push(firstTip);

--- a/js/models/space-colonization/root_segment.js
+++ b/js/models/space-colonization/root_segment.js
@@ -28,7 +28,7 @@ class RootSegment {
     }
 
     let totalPos = new Vector2D(0, 0);
-    let randomModifier = function(vector, delta) { vector.mult(random(1-delta, 1+delta)); return vector; }
+    let randomModifier = function(vector, delta) { vector.mult(UtilFunctions.random(1-delta, 1+delta)); return vector; }
     let vectorAdder = function(total, vector) { total.add(vector); return total; };
     this.targetNutrients
         .map(nutrient => randomModifier(nutrient.pos.copy(), 0.008))

--- a/js/models/space-colonization/root_segment.js
+++ b/js/models/space-colonization/root_segment.js
@@ -1,6 +1,6 @@
 class RootSegment {
   constructor(x, y, parent, plant){
-    this.pos = createVector(x, y);
+    this.pos = new Vector2D(x, y);
     this.parent = parent;
     this.plant = plant;
     this.nutrientDectionRange = this.plant.params.detection_range;
@@ -27,14 +27,14 @@ class RootSegment {
       return;
     }
 
-    let totalPos = createVector(0, 0);
+    let totalPos = new Vector2D(0, 0);
     let randomModifier = function(vector, delta) { vector.mult(random(1-delta, 1+delta)); return vector; }
     let vectorAdder = function(total, vector) { total.add(vector); return total; };
     this.targetNutrients
         .map(nutrient => randomModifier(nutrient.pos.copy(), 0.008))
         .reduce(vectorAdder, totalPos);
 
-    let avgPos = p5.Vector.div(totalPos, this.targetNutrients.length);
+    let avgPos = Vector2D.div(totalPos, this.targetNutrients.length);
 
     if (abs(avgPos.x - this.x) > 1 || abs(avgPos.y - this.y) > 1){
       this.addBranch(avgPos);

--- a/js/models/space-colonization/root_tip.js
+++ b/js/models/space-colonization/root_tip.js
@@ -1,6 +1,6 @@
 class RootTip {
   constructor(x, y, parent, primaryDirection, plant){
-    this.pos = createVector(x, y);
+    this.pos = new Vector2D(x, y);
     this.parent = parent;
     this.direction = primaryDirection;
     this.plant = plant;
@@ -10,7 +10,7 @@ class RootTip {
   get y(){ return this.pos.y; }
 
   length(){
-    return p5.Vector.mag( p5.Vector.sub(this.pos, this.parent.pos) );
+    return Vector2D.mag( Vector2D.sub(this.pos, this.parent.pos) );
   }
 
   tick(){

--- a/js/models/space-colonization/soil.js
+++ b/js/models/space-colonization/soil.js
@@ -1,3 +1,4 @@
+
 class Soil {
   constructor(sizeAndPos, params){
     this.area = sizeAndPos;
@@ -5,7 +6,7 @@ class Soil {
 
     this.nutrients = [];
     for (var i = 0; i< this.params.num_nutrients; i++){
-      let pos = createVector(random(this.area.width), random(this.area.height));
+      let pos = new Vector2D(random(this.area.width), random(this.area.height));
       this.nutrients.push(new Nutrient(pos));
     }
 
@@ -88,7 +89,7 @@ class Soil {
       let idxOfClosest = null;
       for(var i = 0; i < nSeg.segments.length; i++){
         let segment = nSeg.segments[i];
-        let dist = p5.Vector.dist(nSeg.nutrient.pos, segment.pos);
+        let dist = Vector2D.dist(nSeg.nutrient.pos, segment.pos);
         if (dist < segment.nutrientDectionRange && dist < closest){
           idxOfClosest = i;
           closest = dist;

--- a/js/models/space-colonization/soil.js
+++ b/js/models/space-colonization/soil.js
@@ -6,7 +6,7 @@ class Soil {
 
     this.nutrients = [];
     for (var i = 0; i< this.params.num_nutrients; i++){
-      let pos = new Vector2D(random(this.area.width), random(this.area.height));
+      let pos = new Vector2D(UtilFunctions.random(this.area.width), UtilFunctions.random(this.area.height));
       this.nutrients.push(new Nutrient(pos));
     }
 
@@ -31,8 +31,8 @@ class Soil {
 
   placePlantsRandomly(){
     for (var i = 0; i< this.params.num_plants; i++){
-      let xPos = random(this.area.width);
-      let yPos = random(this.area.height);
+      let xPos = UtilFunctions.random(this.area.width);
+      let yPos = UtilFunctions.random(this.area.height);
       let newPlant = new Plant(xPos, yPos, this.params);
       this.plant(newPlant);
     }

--- a/js/models/space-colonization/soil.js
+++ b/js/models/space-colonization/soil.js
@@ -23,7 +23,7 @@ class Soil {
   placePlantsAtGroundLevel(){
     let spacing = this.area.width / (1 + this.params.num_plants);
     for (var i = 0; i< this.params.num_plants; i++){
-      let xPos = floor(spacing * (i + 1));
+      let xPos = Math.floor(spacing * (i + 1));
       let newPlant = new Plant(xPos, 0, this.params);
       this.plant(newPlant);
     }

--- a/js/models/vector_2d.js
+++ b/js/models/vector_2d.js
@@ -1,0 +1,71 @@
+class Vector2D {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  copy() {
+    return new Vector2D(this.x, this.y);
+  }
+
+  mult(factor) {
+    this.x *= factor;
+    this.y *= factor;
+    return this;
+  }
+
+  div(factor) {
+    this.x /= factor;
+    this.y /= factor;
+    return this;
+  }
+
+  add(otherVec) {
+    this.x += otherVec.x;
+    this.y += otherVec.y;
+    return this;
+  }
+
+  sub(otherVec) {
+    this.x -= otherVec.x;
+    this.y -= otherVec.y;
+    return this;
+  }
+
+  magSquared(){
+    return this.x * this.x + this.y * this.y;
+  }
+
+  mag(){
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  }
+
+  distSquared(otherVec){
+    return (this.x - otherVec.x) * (this.x - otherVec.x) +
+           (this.y - otherVec.y) * (this.y - otherVec.y);
+  }
+
+  dist(otherVec){
+    return Math.sqrt((this.x - otherVec.x) * (this.x - otherVec.x) +
+                     (this.y - otherVec.y) * (this.y - otherVec.y));
+  }
+
+  static mult(v, factor) {
+    return new Vector2D(v.x * factor, v.y * factor);
+  }
+  static div(v, factor) {
+    return new Vector2D(v.x / factor, v.y / factor);
+  }
+  static add(v1, v2) {
+    return new Vector2D(v1.x + v2.x, v1.y + v2.y);
+  }
+  static sub(v1, v2) {
+    return new Vector2D(v1.x - v2.x, v1.y - v2.y);
+  }
+  static dist(v1, v2) {
+    return v1.dist(v2);
+  }
+  static mag(v) {
+    return v.mag();
+  }
+}

--- a/js/util_functions.js
+++ b/js/util_functions.js
@@ -98,4 +98,20 @@ class UtilFunctions {
   static round(value, increment = 1){
     return Math.round(value / increment) * increment;
   }
+
+  // match p5.js random() parameter options
+  // see: https://p5js.org/reference/p5/random/
+  //
+  // pass a single number to get a random number between 0 and that number
+  // pass two numbers to get a random number between those two numbers
+  // pass an array to get a random number from that array
+  static random(arg1, arg2){
+    if (Array.isArray(arg1)){
+      return arg1[Math.floor(Math.random() * arg1.length)];
+    }else if (arg2 === undefined){
+      return Math.random() * arg1;
+    }else{
+      return Math.random() * (arg2 - arg1) + arg1;
+    }
+  }
 }

--- a/p5js/common/examples/space-colonization/app.js
+++ b/p5js/common/examples/space-colonization/app.js
@@ -20,6 +20,7 @@ function setup() {
   canvas = createCanvas(windowWidth, windowHeight-40);
   P5JsSettings.init();
   // canvas = createCanvas(500, 500); // for consistent screenshots
+  UtilFunctions.random = random;
 
   // Need to dynamically compute nutrient count, otherwise
   // on larger screens the roots won't consume them all

--- a/p5js/common/examples/space-colonization/index.md
+++ b/p5js/common/examples/space-colonization/index.md
@@ -13,6 +13,7 @@ js_scripts:
 - /sketchbook/p5js/common/p5js_utils.js
 - /sketchbook/js/util_functions.js
 - /sketchbook/js/options_set.js
+- /sketchbook/js/models/vector_2d.js
 - /sketchbook/js/models/rect.js
 - /sketchbook/js/models/quadratic_equation.js
 - /sketchbook/js/layout_util_functions.js

--- a/p5js/common/examples/space-colonization/local_dev.html
+++ b/p5js/common/examples/space-colonization/local_dev.html
@@ -12,6 +12,7 @@
     <script src="/sketchbook/p5js/common/p5js_utils.js" charset="utf-8"></script>
     <script src="/sketchbook/js/util_functions.js" charset="utf-8"></script>
     <script src="/sketchbook/js/options_set.js" charset="utf-8"></script>
+    <script src="/sketchbook/js/models/vector_2D.js" charset="utf-8"></script>
     <script src="/sketchbook/js/models/rect.js" charset="utf-8"></script>
     <script src="/sketchbook/js/models/quadratic_equation.js" charset="utf-8"></script>
     <script src="/sketchbook/js/layout_util_functions.js" charset="utf-8"></script>


### PR DESCRIPTION
Still have two major steps:

1. Rename these classes to be more generic/abstract and useable in other contexts
2. Extract the rendering code specific to p5.js