### PR TITLE
p5js/terrain - Add calculation and rendering of 'aspect' 

### DIFF
--- a/js/models/fields/isolines.js
+++ b/js/models/fields/isolines.js
@@ -33,6 +33,12 @@ class Isolines {
 
     const neighborsIdx = this.field.grid.neighborsOfIdx(i);
 
+    // Neighborhood is:
+    //   0 1 2
+    //   3 - 4
+    //   5 6 7
+    // where '-' is the current cell
+
     const idxToRight = neighborsIdx[4];
     const idxBelow = neighborsIdx[6];
     const idxDownToRight = neighborsIdx[7];

--- a/js/models/fields/terrain.js
+++ b/js/models/fields/terrain.js
@@ -6,4 +6,87 @@ class Terrain extends DiscreteField {
     }
     this.refreshTiers();
   }
+
+  refreshTiers(){
+    super.refreshTiers();
+    this.computeSlopesAndAspects();
+  }
+
+  computeSlopesAndAspects(){
+    this.aspects = [];
+
+    // start at secondRow, secondCol
+    // end at secondToLastRow, secondToLastCol
+    let firstIdx = this.grid.numCols + 1;
+    let lastIdx = this.grid.numCells - this.grid.numCols - 2;
+    for(let i = firstIdx; i < lastIdx; i++){
+      this.computeSlopeAndAspect(i);
+    }
+  }
+  
+  computeSlopeAndAspect(idx){
+    const neighborsIdx = this.grid.neighborsOfIdx(idx);
+
+    // Neighborhood is:
+    //   0 1 2
+    //   3 - 4
+    //   5 6 7
+    // where '-' is the current cell
+
+    // IN ArcGIS terms:
+    // Neighborhood is:
+    //   a b c
+    //   d - f
+    //   g h i
+    // where '-' is the current cell
+    // https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/how-aspect-works.htm
+    //    [dz/dx] = ((c + 2f + i)*4/wght1 - (a + 2d + g)*4/wght2) / 8
+    //    [dz/dy] = ((g + 2h + i)*4/wght3 - (a + 2b + c)*4/wght4 ) / 8
+    // if c, f, and i all have valid values, wght1 = (1+2*1+1) = 4.
+    // if i is NoData, wght1 = (1+2*1+0) = 3.
+    // if f is NoData, wght1 = (1+2*0+1) = 2.
+    // similar for wght2, wght3, and wght4.
+    // aspect = 57.29578 * atan2 ([dz/dy], -[dz/dx])
+    // ... where 57.29578 is the conversion factor from radians to degrees, 180 / PI
+
+    const [wght1, wght2, wght3, wght4] = [4, 4, 4, 4];
+    const a = this.values[neighborsIdx[0]];
+    const b = this.values[neighborsIdx[1]];
+    const c = this.values[neighborsIdx[2]];
+    const d = this.values[neighborsIdx[3]];
+    // const e =  ... skipping over; doesn't factor into calc
+    const f = this.values[neighborsIdx[4]];
+    const g = this.values[neighborsIdx[5]]; 
+    const h = this.values[neighborsIdx[6]];
+    const i = this.values[neighborsIdx[7]];
+
+    const dzdx = ((c + 2*f + i)*4/wght1 - (a + 2*d + g)*4/wght2) / 8;
+    const dzdy = ((g + 2*h + i)*4/wght3 - (a + 2*b + c)*4/wght4 ) / 8;
+    const aspect = 57.29578 * Math.atan2(dzdy, -dzdx); // in degrees  
+
+    this.aspects[idx] = this.convertDegreesToCompassHeading(aspect);
+  }
+
+  // TODO: Move to common JS utils
+  // Convert degrees
+  //  where degree value of 0 is spointing to the right
+  // Output transformed value
+  //  0 is North, 90 is East, 180 is South, and 270 is West
+  convertDegreesToCompassHeading(degrees){
+    // FROM: https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/how-aspect-works.htm
+    if (degrees < 0) {
+      return 90.0 - degrees;
+    }
+    if (degrees > 90.0){
+      return 360.0 - degrees + 90.0;
+    } 
+    return 90.0 - degrees;
+  }
+
+  altConvertDegreesToCompassHeading(degrees){
+    // Normalize to 0-360 degrees
+    degrees = ((degrees % 360) + 360) % 360;
+    // Convert to compass heading
+    return (degrees + 90) % 360;
+  }
 }

--- a/js/models/fields/terrain.js
+++ b/js/models/fields/terrain.js
@@ -1,4 +1,8 @@
 class Terrain extends DiscreteField {
+  init(){
+    super.init();
+    this.aspects = [];
+  }
   
   regenerate(){
     for(let i = 0; i < this.grid.numCells; i++){
@@ -9,12 +13,11 @@ class Terrain extends DiscreteField {
 
   refreshTiers(){
     super.refreshTiers();
+    this.aspects.length = this.values.length;
     this.computeSlopesAndAspects();
   }
 
   computeSlopesAndAspects(){
-    this.aspects = [];
-
     // start at secondRow, secondCol
     // end at secondToLastRow, secondToLastCol
     let firstIdx = this.grid.numCols + 1;

--- a/js/models/fields/terrain.js
+++ b/js/models/fields/terrain.js
@@ -27,6 +27,12 @@ class Terrain extends DiscreteField {
   computeSlopeAndAspect(idx){
     const neighborsIdx = this.grid.neighborsOfIdx(idx);
 
+    // TODO: Formalize the 'sealevel' value; remove majic number of 1
+    if (this.values[idx] < 1){
+      this.aspects[idx] = -1; // below sea level
+      return;
+    }
+
     // Neighborhood is:
     //   0 1 2
     //   3 - 4

--- a/p5js/common/examples/terrain/app.js
+++ b/p5js/common/examples/terrain/app.js
@@ -32,7 +32,9 @@ function setup() {
   terrainGui.add(system.settings, "ySpeed", -5, 5, 0.25).onChange(regenerateSystem);
   terrainGui.add(system.settings, "zSpeed", -0.005, 0.005, 0.0001).onChange(regenerateSystem);
   terrainGui.add(system.settings, "open_simplex_noise").onChange(regenerateSystem);
+  
   const displayGui = gui.addFolder('Display Settings');
+  displayGui.add(system.settings, "base_layer", system.getBaseLayerOptions()).onChange(updateRendering);
   displayGui.add(system.settings, "interpolate_lines").onChange(regenerateSystem);
   displayGui.add(system.settings, "drawLines").onChange(updateRendering);
   displayGui.add(system.settings, "fillRect").onChange(updateRendering);

--- a/p5js/common/examples/terrain/classes/system.js
+++ b/p5js/common/examples/terrain/classes/system.js
@@ -29,10 +29,15 @@ class System {
       { name: "ySpeed", type: "float", default: 0},
       { name: "zSpeed", type: "float", default: 0.0000},
       { name: "open_simplex_noise", type: "bool", default: false},
+      { name: "base_layer", type: "string", default: 'Elevation'},
       { name: "interpolate_lines", type: "bool", default: true},
       { name: "num_levels", type: "integer", default: 16},
       { name: "bin_colors", type: "bool", default: false},
     ];
+  }
+
+  getBaseLayerOptions(){
+    return this.terrainViewer.getBaseLayerOptions();
   }
 
   init(){

--- a/p5js/common/p5js_color_ramp.js
+++ b/p5js/common/p5js_color_ramp.js
@@ -19,6 +19,25 @@ class P5jsColorRamp {
     );
     return _newRamp;
   }
+  
+  static terrainAspect(){
+    const _newRamp = new P5jsColorRamp();
+    _newRamp.setRange(0,360);
+    _newRamp.setColors(
+      [
+        {color: color(220, 0, 0), breakpoint: _newRamp.minValue},
+        {color: color(220, 110, 0), breakpoint: 45},
+        {color: color(220, 220, 0), breakpoint: 90},
+        {color: color(0, 220, 0), breakpoint: 135},
+        {color: color(0, 220, 220), breakpoint: 180},
+        {color: color(0, 180, 180), breakpoint: 225},
+        {color: color(0, 0, 160), breakpoint: 270},
+        {color: color(220, 0, 220), breakpoint: 315},
+        {color: color(230, 0, 0), breakpoint: _newRamp.maxValue}
+      ]
+    );
+    return _newRamp;
+  }
 
   static visibleSpectrum(){
     const _newRamp = new P5jsColorRamp();

--- a/p5js/common/p5js_color_ramp.js
+++ b/p5js/common/p5js_color_ramp.js
@@ -22,10 +22,12 @@ class P5jsColorRamp {
   
   static terrainAspect(){
     const _newRamp = new P5jsColorRamp();
-    _newRamp.setRange(0,360);
+    _newRamp.setRange(-1,360);
     _newRamp.setColors(
       [
-        {color: color(220, 0, 0), breakpoint: _newRamp.minValue},
+        {color: color(150, 150, 150), breakpoint: _newRamp.minValue},
+        {color: color(150, 150, 150), breakpoint: 0},
+        {color: color(220, 0, 0), breakpoint: 0},
         {color: color(220, 110, 0), breakpoint: 45},
         {color: color(220, 220, 0), breakpoint: 90},
         {color: color(0, 220, 0), breakpoint: 135},


### PR DESCRIPTION
* Uses the approach outlined at ESRI: https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/how-aspect-works.htm
* Adds a new ColorRamp for `terrainAspect`

Can be enabled via toggling the new `base_layer` in the GUI;
https://brianhonohan.com/sketchbook/p5js/common/examples/terrain/


----

![elevation](https://github.com/user-attachments/assets/10d143d4-9cf1-455c-a7bc-5915beb99306)


![aspect](https://github.com/user-attachments/assets/2fc996d6-a44b-4340-b162-3b3e163c59cb)

