### PR TITLE
p5js/.../terrain_viewer - Fix bug in pixel rendering of slope or aspect

### DIFF
--- a/js/models/fields/terrain.js
+++ b/js/models/fields/terrain.js
@@ -29,6 +29,15 @@ class Terrain extends DiscreteField {
   }
   
   computeSlopeAndAspect(idx){
+    const isBorder = ( idx % this.grid.numCols == 0) 
+                  || ( idx % this.grid.numCols == (this.grid.numCols - 1) )
+                  || ( Math.trunc(idx / this.grid.numCols) ==  (this.grid.numRows - 1));
+    if (isBorder) { 
+      this.aspects[idx] = undefined;
+      this.slopes[idx] = undefined;
+      return;
+    }
+
     const neighborsIdx = this.grid.neighborsOfIdx(idx);
 
     // TODO: Formalize the 'sealevel' value; remove majic number of 1

--- a/p5js/common/fields/terrain_viewer.js
+++ b/p5js/common/fields/terrain_viewer.js
@@ -53,6 +53,8 @@ class TerrainViewer {
 
     this.elevationRamp.setBinCount(this.system.settings.num_levels);
     this.isolineColorRamp.setBinCount(this.system.settings.num_levels);
+    this.slopeRamp.setBinCount(20);
+    this.aspectRamp.setBinCount(24);
 
     this.rectRenderWidth = Math.floor(this.cellWidth * this.system.settings.rectPercent);
     this.rectRenderHeight = Math.floor(this.cellHeight * this.system.settings.rectPercent);
@@ -164,6 +166,7 @@ class TerrainViewer {
   _fillCellsViaPixels(field){
     loadPixels();
 
+    let cellValue
     let cellX;
     let cellY;
     let j;
@@ -177,11 +180,15 @@ class TerrainViewer {
     let b;
     
     for(let i=0; i<this.dataToRender.length; i++){
+      cellValue = this.dataToRender[i];
+      if (undefined == cellValue){
+        continue;
+      }
       
       cellX = Math.floor((i % this.grid.numCols) * this.cellWidth + this.renderMarginX);
       cellY = Math.floor(Math.floor(i / this.grid.numCols) * this.cellHeight + this.renderMarginY);
 
-      c = this.colorRamp.getBinnedColorForValue(this.dataToRender[i]);
+      c = this.colorRamp.getBinnedColorForValue(cellValue);
       r = red(c);
       g = green(c);
       b = blue(c);


### PR DESCRIPTION
We don't want calculate the slope or aspect on the border row or column. because we're missing the 'neighbor' cells.

Therefore, we need to skip rendering if it wasn't calculated.

(also, the pixel renderer relies on binned colors, so set basic binning for those values).