### PR TITLE
p5js/logic-gates - MINOR - Tweak UI to auto run example on selection

### DIFF
--- a/p5js/logic-gates/app.js
+++ b/p5js/logic-gates/app.js
@@ -27,7 +27,7 @@ function draw(){
 
 function determineVerticalMargin(){
   let fullUrl = window.location.href;
-  return (fullUrl.indexOf(".html") > 0) ? 0 : 37;
+  return (fullUrl.indexOf(".html") > 0) ? 0 : 62;
 }
 
 function initColorScheme(){

--- a/p5js/logic-gates/classes/user_interface.js
+++ b/p5js/logic-gates/classes/user_interface.js
@@ -28,6 +28,8 @@ class UserInterface {
     this.p5Dom_positionToRightOf(this.runButton, this.scenarioSelector);
     this.runButton.mousePressed(this.handleRunScenario);
 
+    this.scenarioSelector.elt.addEventListener('change', this.handleRunScenario.bind(this) );
+
     this.componentRow = [];
     this.componentRow.push(this.scenarioSelector);
     this.componentRow.push(this.runButton);


### PR DESCRIPTION
(and bump the sketch down, to have vertical margin of 62 when rendered on website)

TBD: if it makes sense to remove the RUN button or repurpose it, so leaving it in for now.