### PR TITLE
xp5js/forest-fires-2 - Adjust fire threshold of dry grass

### DIFF
--- a/p5js/forest-fires-02/classes/system.js
+++ b/p5js/forest-fires-02/classes/system.js
@@ -182,7 +182,7 @@ class System {
     this.terrainFireThreshold[System.TERRAIN_SMOLDERING]    = 0.001;
     this.terrainFireThreshold[System.TERRAIN_BURNT]         = 0;
     this.terrainFireThreshold[System.TERRAIN_PARTIAL_BURN]  = 0.0001;
-    this.terrainFireThreshold[System.TERRAIN_GRASS_DRY]     = 0.0010;
+    this.terrainFireThreshold[System.TERRAIN_GRASS_DRY]     = 0.1;
     this.terrainFireThreshold[System.TERRAIN_GRASS_WET]     = 0.1;
     this.terrainFireThreshold[System.TERRAIN_SHRUB]         = 0.5;
     this.terrainFireThreshold[System.TERRAIN_CONIFER]       = 2.3;


### PR DESCRIPTION
Making this the same as GRASS_WET because with the introduction of moisture level (and different initial moisture levels) we've drawn a distinction between these two fuels. And once there is a TOOL_PLANE_WATER_DROP which adds moisture, I want these two to behave the (virtually ) same.

COUNTERPOINT: There is probably a difference in dry grass that has water on it, compared to grass which has internal moisture; maybe in the rate at which it loses moisture due to heat.