### PR TITLE
pixijs/periodic-table - Fix 🐛 bug in resizing after switching the color of the elements

### DIFF
--- a/pixijs/periodic-table/modules/element_viewer.mjs
+++ b/pixijs/periodic-table/modules/element_viewer.mjs
@@ -43,16 +43,12 @@ export class ElementViewer extends Container {
   }
 
   setBackgroundColor(newColor){
-    // THERE HAS TO BE AN EASIER WAY TO PRESERVE THE SCALE
-    let cacheWidth = this.mainRect.width;
-    let cacheHeight = this.mainRect.height;
-    let tmpScale = this.mainRect.scale;;
-
     this.mainRect.clear();
     this.mainRect.beginFill(newColor)
-            .rect(0, 0, cacheWidth / tmpScale.x, cacheHeight / tmpScale.y)
+            .rect(0, 0, 200, 200)
             .endFill()
             .stroke({color: 0xFFFFFF, width: 4 });
+    this.relayout();
   }
 
   setElement(elementData) {


### PR DESCRIPTION
Before this, the table elements would grow by about 1%, such at that after switching between the elements several times it was noticeable

Turns out there was a better way. ;)