### PR TITLE
Site layout - Add PREV / NEXT links to main nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,9 +17,15 @@
       <input type="checkbox" id="tm">
       <ul class="main-menu clearfix">
         {% if page.modal %}
-          {% if page.bh_non_interactive %}
-            <li><a class="page-link" style="text-decoration: none;">(non-interactive)</a></li>
-          {% endif %}
+        {% if page.bh_non_interactive %}
+          <li><a class="page-link" style="text-decoration: none;">(non-interactive)</a></li>
+        {% endif %}
+        {% if page.prev_sketch %}
+          <li><a class="page-link" href="{{page.prev_sketch}}" style="text-decoration: none;">< Prev</a></li>
+        {% endif %}
+        {% if page.next_sketch %}
+          <li><a class="page-link" href="{{page.next_sketch}}" style="text-decoration: none;">Next ></a></li>
+        {% endif %}
         <li><a class="page-link js-modal" href="#"
            data-modal-prefix-class="simple"
            data-modal-content-id="modal-content"

--- a/p5js/coding-challenges/fractal-trees-01/index.md
+++ b/p5js/coding-challenges/fractal-trees-01/index.md
@@ -5,6 +5,7 @@ categories: p5js/coding-challenges
 date: 2018-10-22
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-02/
 excerpt: A basic fractal tree, drawn recursively.
 
 js_scripts:

--- a/p5js/coding-challenges/fractal-trees-02/index.md
+++ b/p5js/coding-challenges/fractal-trees-02/index.md
@@ -5,6 +5,8 @@ categories: p5js/coding-challenges
 date: 2018-10-26
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-01/
+next_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-03/
 excerpt: An interactive iteration on Factal Trees 01, to allow for configuration of branching parameters.
 
 js_scripts:

--- a/p5js/coding-challenges/fractal-trees-03/index.md
+++ b/p5js/coding-challenges/fractal-trees-03/index.md
@@ -6,6 +6,8 @@ date: 2018-11-11
 modal: true
 bh_non_interactive: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-02/
+next_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-04/
 excerpt: Simulates tree growth with apical meristem cells driving growth at the end of branches, which secrete auxin, a growth inhibitor (shown as pink) which prevents lateral growth for little while.
 
 js_scripts:

--- a/p5js/coding-challenges/fractal-trees-04/index.md
+++ b/p5js/coding-challenges/fractal-trees-04/index.md
@@ -5,6 +5,8 @@ categories: p5js/coding-challenges
 date: 2018-11-13
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-03/
+next_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-05/
 excerpt: Coding Challenge (via Coding Train) to implement L-System (Lindenmayer System) tree generation.
 
 js_scripts:

--- a/p5js/coding-challenges/fractal-trees-05/index.md
+++ b/p5js/coding-challenges/fractal-trees-05/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Fractal Trees - Space Colonization"
 categories: p5js/coding-challenges
 date: 2018-11-20
 modal: true
+prev_sketch: /sketchbook/p5js/coding-challenges/fractal-trees-04/
 excerpt: Models root growth based on 'space colonization' algorithm, where roots grow in spurts in an attempt to secure resources.
 
 js_scripts:

--- a/p5js/coding-challenges/marching-squares-2/index.md
+++ b/p5js/coding-challenges/marching-squares-2/index.md
@@ -5,6 +5,8 @@ categories: p5js/coding-challenges
 date: 2025-01-28
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/coding-challenges/marching-squares/
+next_sketch: /sketchbook/p5js/coding-challenges/marching-squares-3/
 excerpt: An iteration of the 'Marching Squares' to do a bit of optimization and add in interpolation.
 
 js_scripts:

--- a/p5js/coding-challenges/marching-squares-3/index.md
+++ b/p5js/coding-challenges/marching-squares-3/index.md
@@ -5,6 +5,7 @@ categories: p5js/coding-challenges
 date: 2025-02-04
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/coding-challenges/marching-squares-2/
 excerpt: An iteration of the 'Marching Squares' to add in multi-level isolines.
 
 js_scripts:

--- a/p5js/coding-challenges/marching-squares/index.md
+++ b/p5js/coding-challenges/marching-squares/index.md
@@ -5,6 +5,7 @@ categories: p5js/coding-challenges
 date: 2025-01-21
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/coding-challenges/marching-squares-2/
 excerpt: A basic implementation of the 'Marching Squares' algorithm to plot the division line between 0 and 1 values in a 2D-field.
 
 js_scripts:

--- a/p5js/coding-challenges/solar-system-3d-texturized/index.md
+++ b/p5js/coding-challenges/solar-system-3d-texturized/index.md
@@ -4,6 +4,8 @@ title:  "p5.js - Solar System 3D Texturized - Coding Challenge #9"
 categories: p5js/coding-challenges
 date: 2018-10-07
 modal: true
+prev_sketch: /sketchbook/p5js/coding-challenges/solar-system-3d/
+
 excerpt: Adds image textures to the 3D objects to display images of the planets in our solar system.
 
 js_scripts:

--- a/p5js/coding-challenges/solar-system-3d/index.md
+++ b/p5js/coding-challenges/solar-system-3d/index.md
@@ -4,6 +4,8 @@ title:  "p5.js - Solar System 3D - Coding Challenge #8"
 categories: p5js/coding-challenges
 date: 2018-10-07
 modal: true
+prev_sketch: /sketchbook/p5js/coding-challenges/solar-system/
+next_sketch: /sketchbook/p5js/coding-challenges/solar-system-3d-texturized/
 excerpt: Added 3D support to the basic solar system sketch simulating gravity of n-bodies.
 
 js_scripts:

--- a/p5js/coding-challenges/solar-system/index.md
+++ b/p5js/coding-challenges/solar-system/index.md
@@ -5,6 +5,7 @@ categories: p5js/coding-challenges
 date: 2018-10-06
 modal: true
 bh_non_interactive: true
+next_sketch: /sketchbook/p5js/coding-challenges/solar-system-3d/
 excerpt: Basic implementation of an n-body gravity simulation; calculates initial orbital velocity of planets to get things going.
 
 js_scripts:

--- a/p5js/common/examples/bezier-2/index.md
+++ b/p5js/common/examples/bezier-2/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2025-02-05
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/bezier/
 excerpt: Demonstrates the additional functionality of a Bezier curve, to get points along the curve and other features.
 
 js_scripts:

--- a/p5js/common/examples/bezier/index.md
+++ b/p5js/common/examples/bezier/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2024-12-29
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/common/examples/bezier-2/
 excerpt: Demonstrates the display and interaction of a Bezier curve modeled as an object, with draggable control points.
 
 js_scripts:

--- a/p5js/common/examples/geometry-circle-line/index.md
+++ b/p5js/common/examples/geometry-circle-line/index.md
@@ -5,6 +5,8 @@ categories: p5js/common/examples
 date: 2025-01-06
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/geometry-line-to-line/
+next_sketch: /sketchbook/p5js/common/examples/shapes-tangents-between-circles/
 excerpt: Demonstration of the algorithm to find intersection of a line with a circle.
 
 js_scripts:

--- a/p5js/common/examples/geometry-line-to-line/index.md
+++ b/p5js/common/examples/geometry-line-to-line/index.md
@@ -5,6 +5,8 @@ categories: p5js/common/examples
 date: 2025-03-25
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/geometry-point-to-line/
+next_sketch: /sketchbook/p5js/common/examples/geometry-circle-line/
 excerpt: Demonstrates determination of line-to-line intersection.
 
 js_scripts:

--- a/p5js/common/examples/geometry-point-to-line/index.md
+++ b/p5js/common/examples/geometry-point-to-line/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2025-01-09
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/geometry-line-to-line/
 excerpt: Demonstrates the point-to-line (nearest point).
 
 js_scripts:

--- a/p5js/common/examples/paisley-2/index.md
+++ b/p5js/common/examples/paisley-2/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2025-02-07
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/paisley/
 excerpt: Demonstrates the drawing of a simple Paisley shape.
 
 js_scripts:

--- a/p5js/common/examples/paisley/index.md
+++ b/p5js/common/examples/paisley/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2021-01-02
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/common/examples/paisley-2/
 excerpt: Demonstrates the drawing of a simple Paisley shape.
 
 js_scripts:

--- a/p5js/common/examples/polybezier/index.md
+++ b/p5js/common/examples/polybezier/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2025-02-05
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/bezier/
 excerpt: Demonstrates the display and interaction of "PolyBezier" (aka Composite Bezier) which is a set of connected bezie-curves.
 
 js_scripts:

--- a/p5js/common/examples/quadtree-2/index.md
+++ b/p5js/common/examples/quadtree-2/index.md
@@ -4,6 +4,8 @@ title:  "p5.js - Common Examples - Quadtree 2"
 categories: p5js/common/examples
 date: 2025-01-05
 modal: true
+prev_sketch: /sketchbook/p5js/common/examples/quadtree/
+next_sketch: /sketchbook/p5js/common/examples/quadtree-3/
 excerpt: Implementation of a quadtree data structure, which groups data points into successively nested quadrants, which allows for fast access of elements in an area.
 
 js_scripts:

--- a/p5js/common/examples/quadtree-3/index.md
+++ b/p5js/common/examples/quadtree-3/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Common Examples - Quadtree 3"
 categories: p5js/common/examples
 date: 2025-03-27
 modal: true
+prev_sketch: /sketchbook/p5js/common/examples/quadtree-2/
 excerpt: Demonstrates storing line segments within a Quadtree structure, and querying by either rectangle or another line-segment.
 
 js_scripts:

--- a/p5js/common/examples/quadtree/index.md
+++ b/p5js/common/examples/quadtree/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Common Examples - Quadtree"
 categories: p5js/common/examples
 date: 2019-02-11
 modal: true
+next_sketch: /sketchbook/p5js/common/examples/quadtree-2/
 excerpt: Implementation of a quadtree data structure, which groups data points into successively nested quadrants, which allows for fast access of elements in an area.
 
 js_scripts:

--- a/p5js/common/examples/shapes-tangents-between-circles/index.md
+++ b/p5js/common/examples/shapes-tangents-between-circles/index.md
@@ -5,6 +5,8 @@ categories: p5js/common/examples
 date: 2018-12-23
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/geometry-circle-line/
+
 excerpt: Demonstrates drawing tangents between two circles.
 
 js_scripts:

--- a/p5js/common/examples/voronoi-2/index.md
+++ b/p5js/common/examples/voronoi-2/index.md
@@ -5,6 +5,8 @@ categories: p5js/common/examples
 date: 2025-01-05
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/voronoi/
+next_sketch: /sketchbook/p5js/common/examples/voronoi-3/
 excerpt: Demonstrates the modified p5.voronoi to have multiple interactive diagrams in one sketch.
 
 js_scripts:

--- a/p5js/common/examples/voronoi-3/index.md
+++ b/p5js/common/examples/voronoi-3/index.md
@@ -5,6 +5,8 @@ categories: p5js/common/examples
 date: 2025-01-08
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/voronoi-2/
+next_sketch: /sketchbook/p5js/common/examples/voronoi-4/
 excerpt: Explores some optimizations in regards to Voronoi diagrams.
 
 js_scripts:

--- a/p5js/common/examples/voronoi-4/index.md
+++ b/p5js/common/examples/voronoi-4/index.md
@@ -5,6 +5,7 @@ categories: p5js/common/examples
 date: 2025-01-12
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/common/examples/voronoi-3/
 excerpt: Explores using the d3-delaunay library to generate the voronoi diagram.
 
 js_scripts:

--- a/p5js/common/examples/voronoi/index.md
+++ b/p5js/common/examples/voronoi/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Common Examples - Voronoi"
 categories: p5js/common/examples
 date: 2025-01-04
 modal: true
+next_sketch: /sketchbook/p5js/common/examples/voronoi-2/
 excerpt: Demonstrates preliminary modified p5.voronoi, working towards multiple interactive diagrams in one sketch.
 
 js_scripts:

--- a/p5js/ecosystem-2/index.md
+++ b/p5js/ecosystem-2/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2025-02-08
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/ecosystem/
 excerpt: An iteration on generated terrain, which adds in resources at different elevations.
 
 js_scripts:

--- a/p5js/ecosystem/index.md
+++ b/p5js/ecosystem/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2017-10-11
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/ecosystem-2/
 excerpt: Randomly generated terrain, with the intention of creating an environment in which an ecosystem can be modeled.
 
 js_scripts:

--- a/p5js/forest-01/index.md
+++ b/p5js/forest-01/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Forest Simulation"
 categories: p5js
 date: 2018-11-01
 modal: true
+next_sketch: /sketchbook/p5js/forest-02/
 excerpt: Simulates the life-cycle of individual trees in a small forest, as they compete over resources.
 
 js_scripts:

--- a/p5js/forest-02/index.md
+++ b/p5js/forest-02/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Forest Simulation 2"
 categories: p5js
 date: 2025-02-12
 modal: true
+prev_sketch: /sketchbook/p5js/forest-01/
 excerpt: Simulates the life-cycle of individual trees of difference species, as they compete over resources.
 
 js_scripts:

--- a/p5js/forest-fires-02/index.md
+++ b/p5js/forest-fires-02/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2019-07-06
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/forest-fires/
 excerpt: Adds interaction to the forest fire simulation sketch, with limits to amount of fire breaks that can be added, and ability to load different scenarios.
 
 js_scripts:

--- a/p5js/forest-fires/index.md
+++ b/p5js/forest-fires/index.md
@@ -4,6 +4,7 @@ title:  "p5.js - Forest Fire Simulation"
 categories: p5js
 date: 2019-06-17
 modal: true
+next_sketch: /sketchbook/p5js/forest-fires-02/
 excerpt: Simulates forest fire propagation using cellular-automaton modeling, with basic interaction to create fire breaks.
 
 js_scripts:

--- a/p5js/friezes-2/index.md
+++ b/p5js/friezes-2/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2025-02-01
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/friezes/
 excerpt: Allows you to draw a frieze, reflecting and translating the lines; with improved drawing features of undo/redo, stroke color and weight, and an animation to redraw the sketch.
 
 js_scripts:

--- a/p5js/friezes/index.md
+++ b/p5js/friezes/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2019-01-28
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/friezes-2/
 excerpt: Allows you to draw a frieze, reflecting the lines you draw through a horizontal line, and repeating off to the right.
 
 js_scripts:

--- a/p5js/nautical-flags-02/index.md
+++ b/p5js/nautical-flags-02/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2019-09-13
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/nautical-flags/
 excerpt: Sketch that allows you to compose a message in nautical flags and get a shareable URL that will re-render the message on a friend's computer.
 
 js_scripts:

--- a/p5js/nautical-flags/index.md
+++ b/p5js/nautical-flags/index.md
@@ -5,6 +5,7 @@ categories: p5js
 date: 2019-08-25
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/nautical-flags-02/
 excerpt: Sketch rendering the various International Maritime Signal Flags, including numbers and Answering pennants, as you type on your keyboard.
 
 js_scripts:

--- a/p5js/random/001/index.md
+++ b/p5js/random/001/index.md
@@ -5,6 +5,7 @@ categories: p5js/random
 date: 2018-12-08
 modal: true
 viewport_noscale: true
+next_sketch: /sketchbook/p5js/random/002/
 excerpt: Click and drage to draw circles sized and colored based on speed of mouse.
 
 js_scripts:

--- a/p5js/random/002/index.md
+++ b/p5js/random/002/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2018-12-11
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/001/
+next_sketch: /sketchbook/p5js/random/003/
 excerpt: Polygons that bounce around the canvas, reminiscent of some Windows 3.1 screensavers. Click to add new vertex, Press c redraw background, and v, b, l to cycle through vertex modes. 
 
 js_scripts:

--- a/p5js/random/003/index.md
+++ b/p5js/random/003/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2022-12-04
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/002/
+next_sketch: /sketchbook/p5js/random/004/
 excerpt: Perlin noise generated lines, similar to Joy Division's 'Unknown Pleasures' album cover.
 
 js_scripts:

--- a/p5js/random/004/index.md
+++ b/p5js/random/004/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-02
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/003/
+next_sketch: /sketchbook/p5js/random/005/
 excerpt: Perlin noise lines, but strokeWeight is based on the noise value.
 
 js_scripts:

--- a/p5js/random/005/index.md
+++ b/p5js/random/005/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-04
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/004/
+next_sketch: /sketchbook/p5js/random/006/
 excerpt: Perlin noise lines, but strokeWeight and color is based on the noise value.
 
 js_scripts:

--- a/p5js/random/006/index.md
+++ b/p5js/random/006/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-19
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/005/
+next_sketch: /sketchbook/p5js/random/007/
 excerpt: Perlin noise cirlces, with size and color based on noise value.
 
 js_scripts:

--- a/p5js/random/007/index.md
+++ b/p5js/random/007/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-20
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/006/
+next_sketch: /sketchbook/p5js/random/008/
 excerpt: Perlin noise cirlces, with size and color based on noise value, and iterating through blendModes.
 
 js_scripts:

--- a/p5js/random/008/index.md
+++ b/p5js/random/008/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-25
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/007/
+next_sketch: /sketchbook/p5js/random/009/
 excerpt: Perlin noise arcs, with size and color based on noise value.
 
 js_scripts:

--- a/p5js/random/009/index.md
+++ b/p5js/random/009/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-26
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/008/
+next_sketch: /sketchbook/p5js/random/010/
 excerpt: Perlin noise arcs, with size and color based on noise value.
 
 js_scripts:

--- a/p5js/random/010/index.md
+++ b/p5js/random/010/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-29
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/009/
+next_sketch: /sketchbook/p5js/random/011/
 excerpt: Perlin noise curves via TRIANGLE_STRIP.
 
 js_scripts:

--- a/p5js/random/011/index.md
+++ b/p5js/random/011/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-04-30
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/010/
+next_sketch: /sketchbook/p5js/random/012/
 excerpt: Perlin noise curves via LINES.
 
 js_scripts:

--- a/p5js/random/012/index.md
+++ b/p5js/random/012/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-05-01
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/011/
+next_sketch: /sketchbook/p5js/random/013/
 excerpt: Perlin noise curves via LINES, connecting noise values resulting in dashed lines (rather than vertical bars in 011).
 
 js_scripts:

--- a/p5js/random/013/index.md
+++ b/p5js/random/013/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-05-02
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/012/
+next_sketch: /sketchbook/p5js/random/014/
 excerpt: Perlin noise curves via TRIANGLES, resulting in something similar to a bar chart, but where each bar is a triangle instead of a rectangle.
 
 js_scripts:

--- a/p5js/random/014/index.md
+++ b/p5js/random/014/index.md
@@ -5,6 +5,8 @@ categories: p5js/random
 date: 2025-05-22
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/013/
+next_sketch: /sketchbook/p5js/random/015/
 excerpt: Perlin noise curves via quad(), resulting in something similar to previous triangle variation, similar to bar chart, but where each bar is a trapezoid instead of a rectangle.
 
 js_scripts:

--- a/p5js/random/015/app.js
+++ b/p5js/random/015/app.js
@@ -20,8 +20,8 @@ var systemParams = {
 };
 
 function setup(){
-  canvas = createCanvas(500, 500);
-  // canvas = createCanvas(windowWidth, windowHeight-determineVerticalMargin());
+  // canvas = createCanvas(500, 500);
+  canvas = createCanvas(windowWidth, windowHeight-determineVerticalMargin());
   colorMode(HSB);
 
   initBlendModeOptions();

--- a/p5js/random/015/index.md
+++ b/p5js/random/015/index.md
@@ -5,6 +5,7 @@ categories: p5js/random
 date: 2025-05-23
 modal: true
 viewport_noscale: true
+prev_sketch: /sketchbook/p5js/random/014/
 excerpt: Perlin noise curves via quad(), resulting in wavy lines draw as bars formed by quadrangles.
 
 js_scripts:


### PR DESCRIPTION
This adds links to main nav to sketches that are part of series

Example: 
https://brianhonohan.com/sketchbook/p5js/common/examples/voronoi-3/
https://brianhonohan.com/sketchbook/p5js/random/002/


----

Probably need to adjust the responsiveness to smaller browser and cutoff point where links collapse to hamburger-menu.