### PR TITLE
p5js/cc/reaction-diffusion - Buffer the cell grid to avoid border-ble…

### DIFF
--- a/js/models/cell_grid.js
+++ b/js/models/cell_grid.js
@@ -93,8 +93,8 @@ class CellGrid {
   }
 
   idxForXY(x, y){
-    let col = floor(x / this.cellWidth);
-    let row = floor(y / this.cellWidth);
+    let col = floor( (x - this._x) / this.cellWidth);
+    let row = floor( (y - this._y) / this.cellWidth);
     return this.idxForRowCol(row, col);
   }
 

--- a/p5js/coding-challenges/reaction-diffusion/classes/system.js
+++ b/p5js/coding-challenges/reaction-diffusion/classes/system.js
@@ -7,7 +7,15 @@ class System {
 
     this.reactionDiff = new ReactionDiffusion();
     this.cellViewer = new CellViewer();
-    this.grid = new CellGrid(this.rect, 
+
+    this.bufferedRect = this.rect.copy();
+    this.gridOffset = this.settings.cellWidth * 15;
+    this.bufferedRect.x -= this.gridOffset;
+    this.bufferedRect.y -= this.gridOffset;
+    this.bufferedRect.width += this.gridOffset * 2;
+    this.bufferedRect.height += this.gridOffset * 2;
+
+    this.grid = new CellGrid(this.bufferedRect, 
                              this, 
                              this.settings.cellWidth,
                              this.cellViewer


### PR DESCRIPTION
…eding

Without this, the diffusion of the chemicals at the border of the canvas would look weird, with the chemicals bleeding around the edges