### PR TITLE
p5js/ex/terrain - Add buffer to not have artificial edges in aspect plotting and isolines; fix jittery scrolling

### DIFF
--- a/js/models/rect.js
+++ b/js/models/rect.js
@@ -12,6 +12,9 @@ class Rect {
   set y(newVal){ this._y = newVal; }
   get width(){ return this._width; }
   get height(){ return this._height; }
+  set width(newVal){ this._width = newVal; }
+  set height(newVal){ this._height = newVal; }
+
   get minX(){ return this._x; }
   get minY(){ return this._y; }
   get maxX(){ return this._x + this._width; }

--- a/p5js/common/examples/terrain/app.js
+++ b/p5js/common/examples/terrain/app.js
@@ -10,7 +10,9 @@ let scaleSettings = {
 let basicUI = {
   dragStartX: undefined,
   dragStartY: undefined,
-  isDragging: false
+  isDragging: false,
+  guiCtrlXSpeed: undefined,
+  guiCtrlYSpeed: undefined,
 }
 
 function setup() {
@@ -28,8 +30,8 @@ function setup() {
   terrainGui.add(system.settings, "cellWidth", 2, 40, 2).onChange(reinitSystem);
   terrainGui.add(scaleSettings, "scale_coarse", 0, 1, 0.01).onChange(updateScale);
   terrainGui.add(scaleSettings, "scale_fine", 0.000001, 0.01, 0.000001).onChange(updateScale);
-  terrainGui.add(system.settings, "xSpeed", -5, 5, 0.25).onChange(regenerateSystem);
-  terrainGui.add(system.settings, "ySpeed", -5, 5, 0.25).onChange(regenerateSystem);
+  guiCtrlXSpeed = terrainGui.add(system.settings, "xSpeed", -5, 5, 0.25).onChange(regenerateSystem);
+  guiCtrlYSpeed = terrainGui.add(system.settings, "ySpeed", -5, 5, 0.25).onChange(regenerateSystem);
   terrainGui.add(system.settings, "zSpeed", -0.005, 0.005, 0.0001).onChange(regenerateSystem);
   terrainGui.add(system.settings, "open_simplex_noise").onChange(regenerateSystem);
   
@@ -70,6 +72,13 @@ function updateRendering(){
 function draw(){
   system.tick();
   system.render();
+
+  updateXYSpeedGuiDisplay();
+}
+
+function updateXYSpeedGuiDisplay(){
+  guiCtrlYSpeed.updateDisplay();
+  guiCtrlXSpeed.updateDisplay();
 }
 
 function mousePressed(event){

--- a/p5js/common/examples/terrain/classes/system.js
+++ b/p5js/common/examples/terrain/classes/system.js
@@ -4,6 +4,9 @@ class System {
     this.optionsSet = new OptionsSet(this.optionsMetadata());
     this.settings = this.optionsSet.settings;
     this.redraw = true;
+    this.needRegeneration = false;
+    this.terrainViewerX = 0;
+    this.terrainViewerY = 0;
 
     this.init();
   }
@@ -77,28 +80,57 @@ class System {
   }
   
   regenerate(){
+    // console.log("Regenerating terrain with settings: ");
     this.applyNoiseSettings();
     this.field.regenerate();
     this.redraw = true;
+    this.needRegeneration = false;
   }
 
   tick(){
-    if (this.settings.xSpeed != 0 || this.settings.ySpeed != 0 || this.settings.zSpeed != 0) { 
-      this.settings.xOffset += this.settings.xSpeed;
-      this.settings.yOffset += this.settings.ySpeed;
-      this.settings.zOffset += this.settings.zSpeed;
-      this.field.regenerate();
-      this.redraw = true;
+    if (this.settings.xSpeed === 0 && this.settings.ySpeed === 0 && this.settings.zSpeed === 0) { 
+      return;
     }
+    this.redraw |= true;
+
+    let regenThreshold = 1; // this.bufferSize;
+    this.terrainViewerX += this.settings.xSpeed;
+    if ( Math.abs(this.terrainViewerX) >= regenThreshold) {
+      let remainder = this.terrainViewerX % regenThreshold;
+      this.settings.xOffset += (this.terrainViewerX - remainder);
+      this.terrainViewerX = remainder;
+      this.needRegeneration |= true;
+    }
+
+    this.terrainViewerY += this.settings.ySpeed;
+    if ( Math.abs(this.terrainViewerY) >= regenThreshold) {
+      let remainder = this.terrainViewerY % regenThreshold;
+      this.settings.yOffset += (this.terrainViewerY - remainder);
+      this.terrainViewerY = remainder;
+      this.needRegeneration |= true;
+    }
+
+    if (this.settings.zSpeed != 0) {
+      this.settings.zOffset += this.settings.zSpeed;
+      this.needRegeneration |= true;
+    }
+
+    if (this.needRegeneration) {
+      this.regenerate();
+    } 
+    // else {
+    //   console.log("No regeneration needed");
+    // }
   }
 
   render(){
-    if (this.redraw == false) {
+    if (this.redraw === false) {
       return;
     }
     background(50);
     push();
-    translate(0 - this.bufferSize, 0 - this.bufferSize);
+    translate( Math.round(0 - this.bufferSize - this.terrainViewerX),
+              Math.round(0 - this.bufferSize - this.terrainViewerY) );
     this.terrainViewer.renderField(this.field);
     pop();
     this.redraw = false;

--- a/p5js/common/examples/terrain/classes/system.js
+++ b/p5js/common/examples/terrain/classes/system.js
@@ -41,7 +41,14 @@ class System {
   }
 
   init(){
-    this.field = new Terrain(this.sizeAndPosition, this.settings);
+    this.bufferedArea = this.sizeAndPosition.copy();
+    this.bufferSize = this.settings.cellWidth;
+    this.bufferedArea.x -= this.bufferSize;
+    this.bufferedArea.y -= this.bufferSize;
+    this.bufferedArea.width += 2 * this.bufferSize;
+    this.bufferedArea.height += 2 * this.bufferSize;
+
+    this.field = new Terrain(this.bufferedArea, this.settings);
     // TODO: Remove the need to regerate again
     // this is necessary bease of the dynamic injection of the p5.js noise()
     // ... which is only done after the object is created
@@ -90,7 +97,10 @@ class System {
       return;
     }
     background(50);
+    push();
+    translate(0 - this.bufferSize, 0 - this.bufferSize);
     this.terrainViewer.renderField(this.field);
+    pop();
     this.redraw = false;
   }
 }


### PR DESCRIPTION
The algorithms for isolines and aspect calculation require full neighbors.

This adds a slight buffer in cells around the viewable area so those algorithms don't have arbitrary 