### PR TITLE
p5js/crowd-simulation - Adjust separation factor and make doorways rectangles

### DIFF
--- a/p5js/crowd-simulation/app.js
+++ b/p5js/crowd-simulation/app.js
@@ -21,9 +21,9 @@ function setup(){
   gui.add(guiOptions, 'fadeEffect', 0, 1, 0.01);
 
   let flowGui = gui.addFolder('Flow');
-  flowGui.add(publicSpace.defaultFlowBehavior.config, 'separationFactor', 0, 3, 0.1);
-  flowGui.add(publicSpace.defaultFlowBehavior.config, 'alignFactor', 0, 3, 0.1);
-  flowGui.add(publicSpace.defaultFlowBehavior.config, 'cohesionFactor', 0, 3, 0.1);
+  flowGui.add(publicSpace.defaultFlowBehavior.config, 'separationFactor', 0, 5, 0.1);
+  flowGui.add(publicSpace.defaultFlowBehavior.config, 'alignFactor', 0, 5, 0.1);
+  flowGui.add(publicSpace.defaultFlowBehavior.config, 'cohesionFactor', 0, 5, 0.1);
   flowGui.add(publicSpace.defaultFlowBehavior.config, 'desiredSeparation', 0, 100, 1);
   flowGui.add(publicSpace.defaultFlowBehavior.config, 'maxSpeed', 0.5, 9, 0.5);
   flowGui.add(publicSpace.defaultFlowBehavior.config, 'maxForce', 0.05, 1, 0.05);

--- a/p5js/crowd-simulation/classes/crowd_flow_behavior.js
+++ b/p5js/crowd-simulation/classes/crowd_flow_behavior.js
@@ -25,11 +25,11 @@ class CrowdFlowBehavior {
 
   defaultSettings(){
     return {
-      separationFactor: 0.8,
+      separationFactor: 2.5,
       alignFactor: 0.9,
       cohesionFactor: 0.6,
       desiredSeparation: 20,
-      maxSpeed: 3,
+      maxSpeed: 2,
       maxForce: 0.05
     };
   }
@@ -102,11 +102,17 @@ class CrowdFlowBehavior {
     const steer = createVector(0, 0);
     let countTooClose = 0;
 
+    let desiredSeparation = this.config.desiredSeparation;
+    if (boid.loc.dist(boid.target) < desiredSeparation){
+      // 
+      desiredSeparation = boid.size;
+    }
+
     for (var i = 0; i < fovData.neighbors.length; i++){
       let other = fovData.neighbors[i];
 
       let dist = fovData.distances[i];
-      if (dist > this.config.desiredSeparation){
+      if (dist > desiredSeparation){
         continue;
       }
 

--- a/p5js/crowd-simulation/classes/crowd_member.js
+++ b/p5js/crowd-simulation/classes/crowd_member.js
@@ -17,7 +17,7 @@ class CrowdMember {
 
   setTarget(doorwayEnd){
     this.targetDoorway = doorwayEnd;
-    this.target = this.targetDoorway.position;
+    this.target = this.targetDoorway.exitPosition;
     this.velocity = p5.Vector.sub(this.target, this.loc);
     this.velocity.normalize();
     this.velocity.mult(0.5);

--- a/p5js/crowd-simulation/classes/crowd_member.js
+++ b/p5js/crowd-simulation/classes/crowd_member.js
@@ -11,6 +11,9 @@ class CrowdMember {
     this.targetDoorway = undefined;
   }
 
+  static get size() { return 10; }
+  get size() { return CrowdMember.size; }
+
   setStart(doorwayStart){
     this.startDoorway = doorwayStart;
   }
@@ -29,8 +32,6 @@ class CrowdMember {
   get minY(){ return this.loc.y - CrowdMember.size; }
   get maxX(){ return this.loc.x + CrowdMember.size; }
   get maxY(){ return this.loc.y + CrowdMember.size; }
-
-  static get size() { return 10; }
 
   tick(){
     this.neighbors = this.publicSpace.crowdNearby(this.x, this.y);

--- a/p5js/crowd-simulation/classes/doorway.js
+++ b/p5js/crowd-simulation/classes/doorway.js
@@ -1,17 +1,29 @@
 class Doorway {
-  constructor(x, y, publicSpace, colorValue) {
+  constructor(x, y, publicSpace, colorValue, rotation = 0) {
     this.position = createVector(x, y);
-    this.radius = 10; // Radius for interaction
+    this.openingSize = 50;
     this.publicSpace = publicSpace; // Reference to the public space
     this.color = colorValue;
 
     // slightly hacky; build object to support GUI color controls
     this.rgbColor = {r: colorValue.levels[0], g: colorValue.levels[1], b: colorValue.levels[2]};
     this.spawnMatrix = undefined;
+    this.rotation = rotation;
+
+    this.exitPosition = createVector(this.x + this.width, this.y + this.height);
   }
+
+  static get DEPTH () { return 10; }
 
   get x(){ return this.position.x; }
   get y(){ return this.position.y; }
+
+  set rotation(newVal){ 
+    this._rotation = newVal;
+    this.width = Math.cos(newVal) * this.openingSize + Math.sin(newVal) * Doorway.DEPTH;
+    this.height = Math.sin(newVal) * this.openingSize + Math.cos(newVal) * Doorway.DEPTH;
+  }
+  get rotation(){ return this._rotation; }
 
   tick(){
     this.spawnNewCrowdMembers();
@@ -36,7 +48,8 @@ class Doorway {
   }
 
   exitCrowdMembers() {
-    let nearbyCrowdMembers = this.publicSpace.crowdWithin(this.x, this.y, 10);
+    let nearbyCrowdMembers = this.publicSpace.crowdWithin(this.exitPosition.x,
+                                                          this.exitPosition.y, 10);
     for (let i = 0; i < nearbyCrowdMembers.length; i++) {
       let crowdMember = nearbyCrowdMembers[i];
       if (crowdMember.startDoorway === this) {
@@ -49,6 +62,6 @@ class Doorway {
   draw() {
     fill(this.color);
     noStroke();
-    ellipse(this.x, this.y, this.radius * 2);
+    rect(this.x, this.y, this.width, this.height);
   }
 }

--- a/p5js/crowd-simulation/classes/system.js
+++ b/p5js/crowd-simulation/classes/system.js
@@ -28,12 +28,14 @@ class System {
     this.doorways.push(new Doorway(
       this.x,
       this.y + (0.25 + 0.5 * random()) * this.height,
-      this, color(baseHue, 90, 90)
+      this, color(baseHue, 90, 90),
+      HALF_PI
     ));
     this.doorways.push(new Doorway(
-      this.x + this.width,
+      this.x + this.width - Doorway.DEPTH,
       this.y + (0.25 + 0.5 * random()) * this.height,
-      this, color( (baseHue + 90 * 1) % 360, 90, 90)
+      this, color( (baseHue + 90 * 1) % 360, 90, 90),
+      HALF_PI
     ));
     this.doorways.push(new Doorway(
       this.x + (0.25 + 0.5 * random()) * this.width,
@@ -42,7 +44,7 @@ class System {
     ));
     this.doorways.push(new Doorway(
       this.x + (0.25 + 0.5 * random()) * this.width,
-      this.y + this.height,
+      this.y + this.height - Doorway.DEPTH,
       this, color( (baseHue + 90 * 3) % 360, 90, 90)
     ));
   }


### PR DESCRIPTION
Adjust the separation factor (increase it) so that that CrowdMembers don't pass through each other.

In doing so, need to establish a separate exit point from the spawn point
Otherwise incoming CrowdMembers would prevent others from exiting.

So went with a basic rectangle to represent the door way, with opposing corners (roughly speaking) being an entrance and exit point.  