### PR TITLE
p5js/thermal (and others) Update to send include meta content utf-8

### DIFF
--- a/p5js/common/examples/voronoi-2/local_dev.html
+++ b/p5js/common/examples/voronoi-2/local_dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Examples - Voronoi 2</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 

--- a/p5js/common/examples/voronoi/local_dev.html
+++ b/p5js/common/examples/voronoi/local_dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Examples - Voronoi</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 

--- a/p5js/keyviz/local_dev.html
+++ b/p5js/keyviz/local_dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Keyboard Viz</title>
 
     <script src="/sketchbook/vendor/p5.js/0.7.2/p5.js" charset="utf-8"></script>

--- a/p5js/logic-gates/local_dev.html
+++ b/p5js/logic-gates/local_dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - sketch_template</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 

--- a/p5js/nautical-flags-02/local-dev.html
+++ b/p5js/nautical-flags-02/local-dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Nautical Flags</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 

--- a/p5js/nautical-flags-03/local-dev.html
+++ b/p5js/nautical-flags-03/local-dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Nautical Flags 3</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 

--- a/p5js/thermal-cells/local_dev.html
+++ b/p5js/thermal-cells/local_dev.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>P5.JS - Thermal Cells</title>
     <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width">
 


### PR DESCRIPTION
In particular this issue impacts use of lil-gui, with folders Because it uses some unicode characters for the drop-down caret/chevron