### PR TITLE
p5js - general cleanup - Autohide the GUI console if the screen is narrow

### DIFF
--- a/p5js/coding-challenges/lorenz-attractor/app.js
+++ b/p5js/coding-challenges/lorenz-attractor/app.js
@@ -14,7 +14,7 @@ var systemParams = {
 function setup(){
   createCanvas(windowWidth, windowHeight-35, WEBGL);
 
-  gui = new dat.gui.GUI();
+  gui = P5JsSettings.addGui({autoPlace: false});
   gui.add(systemParams, "rho").min(1).max(50).step(0.1);
   gui.add(systemParams, "sigma").min(1).max(30).step(0.1);
   gui.add(systemParams, "beta").min(1).max(30).step(0.1);

--- a/p5js/coding-challenges/marching-squares-2/app.js
+++ b/p5js/coding-challenges/marching-squares-2/app.js
@@ -41,6 +41,7 @@ function setup() {
   gui.add(system.settings, "interpolate_lines").onChange(regenerateSystem);
   gui.add(system.settings, "fillRect");
   gui.add(system.settings, "drawGrid");
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function regenerateSystem(){

--- a/p5js/coding-challenges/marching-squares-3/app.js
+++ b/p5js/coding-challenges/marching-squares-3/app.js
@@ -26,6 +26,8 @@ function setup() {
   gui.add(system.settings, "rectPercent", 0.05, 1, 0.01).onChange(updateRendering);
   gui.add(system.settings, "drawGrid");
   gui.add(system.settings, "num_levels", 2, 20, 1).onChange(updateRendering);
+  
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function regenerateSystem(){

--- a/p5js/coding-challenges/reaction-diffusion/app.js
+++ b/p5js/coding-challenges/reaction-diffusion/app.js
@@ -27,6 +27,7 @@ function setup() {
   gui.add(guiProxy, 'resetDefaults').name('Reset Factors');
 
   background(50);
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){

--- a/p5js/common/examples/bezier-2/app.js
+++ b/p5js/common/examples/bezier-2/app.js
@@ -41,6 +41,7 @@ function setup() {
   tangentGui.add(settings.tangent, "perpendicular_length", 5, 200, 5);
 
   drawIntermediatePoints();
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){

--- a/p5js/common/examples/paisley-2/app.js
+++ b/p5js/common/examples/paisley-2/app.js
@@ -80,6 +80,7 @@ function setup() {
   // TODO: enable basic layer stack of drawable objects
   // ... with send to back, bring to front, send to bottom, bring to top functions
   shapes.push(paisley);
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){

--- a/p5js/common/examples/space-colonization/app.js
+++ b/p5js/common/examples/space-colonization/app.js
@@ -101,6 +101,7 @@ function setup() {
     system.addNewComponents();
 
   }
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){

--- a/p5js/common/p5js_settings.js
+++ b/p5js/common/p5js_settings.js
@@ -108,6 +108,12 @@ class P5JsSettings {
     return container;
   }
 
+  static collapseGuiIfNarrow(gui){
+    if (window.innerWidth < 500) {
+      gui.close();
+    }
+  }
+
   static setSeed(seed){
     this.optionsSet.settings.seed = seed;
     randomSeed(this.optionsSet.settings.seed);

--- a/p5js/crowd-simulation/app.js
+++ b/p5js/crowd-simulation/app.js
@@ -29,6 +29,7 @@ function setup(){
   flowGui.add(publicSpace.defaultFlowBehavior.config, 'maxForce', 0.05, 1, 0.05);
 
   addGuiControlsForDoorwaySpawnMatrices();
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){

--- a/p5js/forest-02/app.js
+++ b/p5js/forest-02/app.js
@@ -38,6 +38,8 @@ function setup() {
   addGuiForSpecies(system.forest.treeSpecies[0]);
   addGuiForSpecies(system.forest.treeSpecies[1]);
   addGuiForSpecies(system.forest.treeSpecies[2]);
+
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function addGuiForSpecies(species){

--- a/p5js/friezes-2/app.js
+++ b/p5js/friezes-2/app.js
@@ -40,6 +40,7 @@ function setup() {
   gui.add(settings, "animationSpeed", 1, 10, 1).onChange(animatePen);
 
   drawBackground();
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function createPen(){

--- a/p5js/voronoi-herd/voronoi_herd_behavior.js
+++ b/p5js/voronoi-herd/voronoi_herd_behavior.js
@@ -61,6 +61,7 @@ function setup(){
   addGuiListeners();
 
   initSystem();
+  P5JsSettings.collapseGuiIfNarrow(gui);
 }
 
 function draw(){


### PR DESCRIPTION

Avoid having the user hit with  a complicated GUI config screen on first load.