### PR TITLE
js/models - Fix issues related to JS number precision and interaction point checks

### DIFF
--- a/js/models/line_seg.js
+++ b/js/models/line_seg.js
@@ -97,7 +97,7 @@ class LineSeg {
     let slope = this.slope;
     if (slope == Infinity || slope == -Infinity){
       return new VerticalLine(this.startX);
-    } else if (slope == 0){
+    } else if (Math.abs(slope) <= 0.0000000001 ){
       return new HorizontalLine(this.startY);
     }
 

--- a/js/models/rect.js
+++ b/js/models/rect.js
@@ -96,8 +96,8 @@ class Rect {
   static pointsContainXY(p1x, p1y, p2x, p2y, x, y){
     // applies an epsilon check for vertical or horizontal lines as search rectangles
     return ( (Math.min(p1x, p2x) <= x && x <= Math.max(p1x, p2x) ) 
-              || (p1x === p2x  && Math.abs(p1x - x) < 0.000001))
+              || (Math.abs(p1x - p2x) < 0.000001 && Math.abs(p1x - x) < 0.000001))
           && ( (Math.min(p1y, p2y) <= y && y <= Math.max(p1y, p2y))
-              || (p1y === p2y && Math.abs(p1y - y) < 0.000001));
+              || (Math.abs(p1y - p2y) < 0.000001 && Math.abs(p1y - y) < 0.000001));
   }
 }

--- a/js/models/voronoi_ext.js
+++ b/js/models/voronoi_ext.js
@@ -357,12 +357,9 @@ if (typeof(Voronoi) === 'function'){
             this.vertices.push(vertexB);
           }
 
-          let newEdge = {
-            lSite: cell.site,
-            rSite: undefined,
-            va: vertexA,
-            vb: vertexB,
-          };
+          let newEdge = new Voronoi.prototype.Edge(cell.site, undefined);
+          newEdge.va = vertexA;
+          newEdge.vb = vertexB;
           let newHalfEdge = new Voronoi.prototype.Halfedge(newEdge, cell.site, undefined);
           cell.halfedges.splice(j + k + 1, 0, newHalfEdge);
           


### PR DESCRIPTION
Fixes issues related to some floating point precision

Now:
- If the slope is very small, it is treated as a HorizontalLine
- And in Rectangle check, it also has flexibility for the the x and y values to be very close, and thus if they are really close, and the point in question is really close, the point is considered to be in the rectangle

(should maybe set a threshold on that one)

Want to look into Number.toPrecision()
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
16f3f0a


---

*Ultimately do not want to use a library; because I don’t want to have to interact with an object to do math.* 
* BigDecimal JS https://github.com/royNiladri/js-big-decimal
    * ⛔ Requires consumer code to interact with custom object 
* DecimalJS https://mikemcl.github.io/decimal.js/
    * ⛔ Requires consumer code to interact with custom object 


