### PR TITLE
devlog - revert deletion of post

### DIFF
--- a/_posts/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
+++ b/_posts/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title:  "Processing - Exploring Fermat's Spiral and Vogel's Model using the Golden Angle"
+date:   2015-01-24 12:00:00 -0400
+categories: [processing]
+thumbnail: /sketchbook/processing/spirals/screenshot-01.png
+excerpt: This is a Processing sketch inspired by the Fermat spiral; which is closely related to the arrangement of sunflower seeds (phyllotaxis).
+
+js_scripts:
+- https://cdnjs.cloudflare.com/ajax/libs/processing.js/1.6.6/processing.js
+
+---
+
+<canvas data-processing-sources="/sketchbook/processing/spirals/spirals.pde"></canvas>
+
+## Overview
+
+This is a [Processing][processing-home] sketch inspired by the [Fermat spiral][wiki-fermat-spiral]; which is closely related to the arrangement of sunflower seeds ([phyllotaxis][wiki-phyllotaxis]).
+
+Keys:
+
+- `<any_key>` Resets the angle to the [Golden angle][wiki-golden-angle].
+- `?` hides / shows a help menu
+
+Mouse:
+
+- Mouse movement sets the angle used within the [Fermat Spiral][wiki-fermat-spiral]
+
+Source code: ([View on Github][source-code])
+
+[processing-home]: https://processing.org
+[wiki-fermats-spiral]: https://en.wikipedia.org/wiki/Fermat%27s_spiral
+[wiki-phyllotaxis]: https://en.wikipedia.org/wiki/Phyllotaxis
+[wiki-golden-angle]: https://en.wikipedia.org/wiki/Golden_angle
+[wiki-fermat-spiral]: https://en.wikipedia.org/wiki/Fermat%27s_spiral
+[source-code]: https://github.com/brianhonohan/sketchbook/blob/master/processing/spirals/spirals.pde


### PR DESCRIPTION
Tried in place migration up to top-level repo, but doesn't appear that Github pages routing allows for two repos to serve the same path

Will probably shift to meta-refreshes (because I don't like the idea of breaking URLs)