### PR TITLE
posts - Establish (test) redirect for fermat-spirals post

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -69,10 +69,11 @@ layout: default
   {%- endfor -%}
 
 
-  {%- if site.posts.size > 0 -%}
+  {% assign filtered_posts = site.posts | where_exp: "page", "page.layout != 'redirect'" | sort: 'date' | reverse %}
+  {%- if filtered_posts.size > 0 -%}
     <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
     <ul class="post-list util-clear">
-      {%- for post in site.posts -%}
+      {%- for post in filtered_posts -%}
       <li class="util-clear">
         {% if post.thumbnail %}
         <div class="listing-thumbnail">

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+    <link rel="canonical" href="{{ page.redirect_to }}" />
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>If you are not redirected, <a href="{{ page.redirect_to }}">click here</a>.</p>
+</body>
+</html>

--- a/_posts/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
+++ b/_posts/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
@@ -1,36 +1,8 @@
 ---
-layout: post
-title:  "Processing - Exploring Fermat's Spiral and Vogel's Model using the Golden Angle"
+layout: redirect
 date:   2015-01-24 12:00:00 -0400
 categories: [processing]
-thumbnail: /sketchbook/processing/spirals/screenshot-01.png
-excerpt: This is a Processing sketch inspired by the Fermat spiral; which is closely related to the arrangement of sunflower seeds (phyllotaxis).
-
-js_scripts:
-- https://cdnjs.cloudflare.com/ajax/libs/processing.js/1.6.6/processing.js
+redirect_to: https://brianhonohan.com/posts/sketchbook/2015/01/24/fermat-spirals-vogel-angle-phyllotaxis.html
 
 ---
 
-<canvas data-processing-sources="/sketchbook/processing/spirals/spirals.pde"></canvas>
-
-## Overview
-
-This is a [Processing][processing-home] sketch inspired by the [Fermat spiral][wiki-fermat-spiral]; which is closely related to the arrangement of sunflower seeds ([phyllotaxis][wiki-phyllotaxis]).
-
-Keys:
-
-- `<any_key>` Resets the angle to the [Golden angle][wiki-golden-angle].
-- `?` hides / shows a help menu
-
-Mouse:
-
-- Mouse movement sets the angle used within the [Fermat Spiral][wiki-fermat-spiral]
-
-Source code: ([View on Github][source-code])
-
-[processing-home]: https://processing.org
-[wiki-fermats-spiral]: https://en.wikipedia.org/wiki/Fermat%27s_spiral
-[wiki-phyllotaxis]: https://en.wikipedia.org/wiki/Phyllotaxis
-[wiki-golden-angle]: https://en.wikipedia.org/wiki/Golden_angle
-[wiki-fermat-spiral]: https://en.wikipedia.org/wiki/Fermat%27s_spiral
-[source-code]: https://github.com/brianhonohan/sketchbook/blob/master/processing/spirals/spirals.pde


### PR DESCRIPTION
Moving all posts up to top-level repo

Testing / validating this redirect

Should redirect: https://brianhonohan.com/sketchbook/processing/2015/01/24/fermat-spirals-vogel-angle-phyllotaxis.html

To: https://brianhonohan.com/posts/sketchbook/2015/01/24/fermat-spirals-vogel-angle-phyllotaxis.html 