### PR TITLE
p5js/random - Tweak the initialization to match the screenshot

### DIFF
--- a/p5js/random/021/app.js
+++ b/p5js/random/021/app.js
@@ -5,6 +5,7 @@ let vertMargin = determineVerticalMargin();
 let gui;
 let modeOptions;
 let paletteColors;
+let isFirstSetup = true;
 
 function setup() {
   // canvas = createCanvas(500, 500); // for screenshots
@@ -59,6 +60,11 @@ function handleModeChange(){
       // Fixes breaking issue with voronoi generation
       option.maxValue = 359.9999;
     }
+    if (isFirstSetup && option.name == 'scalingFactor'){
+      modeOptions[option.name] = 28.5;
+      isFirstSetup = false;
+    }
+
     switch (option.type) {
       case 'list':
         folder.add(modeOptions, option.name, option.options).onFinishChange(regenerate);

--- a/p5js/random/021/classes/system.js
+++ b/p5js/random/021/classes/system.js
@@ -72,7 +72,7 @@ class System {
   // supported types: integer, float, string, bool
   optionsMetadata(){
     return [
-      { name: "num_points", type: "integer", default: 500},
+      { name: "num_points", type: "integer", default: 2000},
       { name: "mode", type: "String", default: 'spiral-fermat'},
       { name: "homing_points", type: "bool", default: true},
       


### PR DESCRIPTION
This allows the sketch to match the screenshot, with the nicer color gradient.